### PR TITLE
specify primary key ids in test sql script

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE tests (
   query_params JSONB,
   teardown text,
   status text NOT NULL,
+  eb_rule_arn text,
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMP
 );
@@ -110,8 +111,6 @@ CREATE TABLE assertion_results (
   pass BOOLEAN NOT NULL
 ); 
 
-
-
 -- CREATE TABLE slack_alerts (
 --   id serial PRIMARY KEY,
 --   webhook text NOT NULL,
@@ -120,6 +119,3 @@ CREATE TABLE assertion_results (
 --     REFERENCES notification_settings (id)
 --     ON DELETE CASCADE
 -- );
-
-
-

--- a/sql/test_data.sql
+++ b/sql/test_data.sql
@@ -1,6 +1,6 @@
-INSERT INTO tests (id, name, run_frequency_mins, method, url, headers, payload, status)
-  VALUES (100000, 'first_get_test', 60, 'GET', 'https://trellific.corkboard.dev/api/boards','{}','{}', 'RUNNING'),
-         (100001,'first_post_test', 60, 'POST', 'https://trellific.corkboard.dev/api/boards', '{"Content-Type": "application/json"}', '{"board":{"title":"post-test-board"}}', 'RUNNING');
+INSERT INTO tests (id, name, run_frequency_mins, method, url, headers, payload, status, eb_rule_arn)
+  VALUES (100000, 'first_get_test', 60, 'GET', 'https://trellific.corkboard.dev/api/boards','{}','{}', 'RUNNING', 'arn:imfake'),
+         (100001,'first_post_test', 60, 'POST', 'https://trellific.corkboard.dev/api/boards', '{"Content-Type": "application/json"}', '{"board":{"title":"post-test-board"}}', 'RUNNING', 'arn:imfake');
 
 INSERT INTO notification_settings (id, alerts_on_recovery, alerts_on_failure)
   VALUES (100000, false, true),

--- a/sql/test_data.sql
+++ b/sql/test_data.sql
@@ -1,65 +1,65 @@
-INSERT INTO tests (name, run_frequency_mins, method, url, headers, payload, status)
-  VALUES ('first-get-test', 60, 'GET', 'https://trellific.corkboard.dev/api/boards','{}','{}', 'RUNNING'),
-         ('first-post-test', 60, 'POST', 'https://trellific.corkboard.dev/api/boards', '{"Content-Type": "application/json"}', '{"board":{"title":"post-test-board"}}', 'RUNNING');
+INSERT INTO tests (id, name, run_frequency_mins, method, url, headers, payload, status)
+  VALUES (100000, 'first_get_test', 60, 'GET', 'https://trellific.corkboard.dev/api/boards','{}','{}', 'RUNNING'),
+         (100001,'first_post_test', 60, 'POST', 'https://trellific.corkboard.dev/api/boards', '{"Content-Type": "application/json"}', '{"board":{"title":"post-test-board"}}', 'RUNNING');
 
-INSERT INTO notification_settings (alerts_on_recovery, alerts_on_failure)
-  VALUES (false, true),
-         (true, true);
+INSERT INTO notification_settings (id, alerts_on_recovery, alerts_on_failure)
+  VALUES (100000, false, true),
+         (100001, true, true);
 
-INSERT INTO alerts (type, webhook, notification_settings_id)
-  VALUES ('discord', 'https://discord.com/api/webhooks/995792660373704754/3mcFoIu3ZcbccyiSWbYqxvMPSKtbX7DGpHGXDjP7k_Oz5CgC6xXb_SgNdbiXxPsQZ1EC', 1),
-  ('discord', 'https://discord.com/api/webhooks/995792660373704754/3mcFoIu3ZcbccyiSWbYqxvMPSKtbX7DGpHGXDjP7k_Oz5CgC6xXb_SgNdbiXxPsQZ1EC', 2);
+INSERT INTO alerts (id, type, webhook, notification_settings_id)
+  VALUES (100000, 'discord', 'https://discord.com/api/webhooks/995792660373704754/3mcFoIu3ZcbccyiSWbYqxvMPSKtbX7DGpHGXDjP7k_Oz5CgC6xXb_SgNdbiXxPsQZ1EC', 100000),
+  (100001, 'discord', 'https://discord.com/api/webhooks/995792660373704754/3mcFoIu3ZcbccyiSWbYqxvMPSKtbX7DGpHGXDjP7k_Oz5CgC6xXb_SgNdbiXxPsQZ1EC', 100001);
 
 INSERT INTO tests_alerts (test_id, alerts_id)
-  VALUES (3,2),
-         (4,3);
+  VALUES (100000,100000),
+         (100001,100001);
 
-INSERT INTO comparison_types (name, symbol)
-  VALUES ('equal_to', '='),
-         ('greather_than', '>'),
-         ('less_than', '<'),
-         ('greater_than_or_equal_to', '>='),
-         ('less_than_or_equal_to', '<=');
+INSERT INTO comparison_types (id, name, symbol)
+  VALUES (100000, 'equal_to', '='),
+         (100001, 'greather_than', '>'),
+         (100002, 'less_than', '<'),
+         (100003, 'greater_than_or_equal_to', '>='),
+         (100004, 'less_than_or_equal_to', '<=');
 
-INSERT INTO assertions (test_id, type, property, comparison_type_id, expected_value)
-  VALUES (3, 'status_code', null, 1, '200'),
-         (3, 'response_time_ms', null, 5, '500'),
-         (4, 'status_code', null, 1, '201'),
-         (4, 'response_time_ms', null, 5, '600'),
-         (4, 'contains_property', null, 1, 'title'),
-         (4, 'contains_value','title', 1, 'my-test-board');
+INSERT INTO assertions (id, test_id, type, property, comparison_type_id, expected_value)
+  VALUES (100000, 100000, 'status_code', null, 100000, '200'),
+         (100001, 100000, 'response_time_ms', null, 100004, '500'),
+         (100002, 100001, 'status_code', null, 100000, '201'),
+         (100003, 100001, 'response_time_ms', null, 100004, '600'),
+         (100004, 100001, 'contains_property', null, 100000, 'title'),
+         (100005, 100001, 'contains_value','title', 100000, 'my-test-board');
 
-INSERT INTO regions (display_name, aws_name, flag_url)
-  VALUES ('Virginia', 'us-east-1', 'https://img.icons8.com/office/344/usa.png'),
-         ('Montreal', 'ca-central-1', 'https://img.icons8.com/office/344/canada.png'),
-         ('Stockholm', 'eu-north-1', 'https://img.icons8.com/offices/344/sweden.png');
+INSERT INTO regions (id, display_name, aws_name, flag_url)
+  VALUES (100000, 'Virginia', 'us-east-1', 'https://img.icons8.com/office/344/usa.png'),
+         (100001, 'Montreal', 'ca-central-1', 'https://img.icons8.com/office/344/canada.png'),
+         (100002, 'Stockholm', 'eu-north-1', 'https://img.icons8.com/offices/344/sweden.png');
 
 INSERT INTO tests_regions (test_id, region_id)
-  VALUES (3, 1),
-         (3, 2),
-         (3, 3),
-         (4, 1),
-         (4, 3);
+  VALUES (100000, 100000),
+         (100000, 100001),
+         (100000, 100002),
+         (100001, 100000),
+         (100001, 100002);
 
-INSERT INTO test_runs (test_id, started_at, completed_at, pass, region_id)
-  VALUES (3, NOW(), NOW(), true, 1),
-         (3, NOW(), NOW(), true, 2),
-         (3, NOW(), NOW(), true, 3),
-         (4, NOW(), NOW(), true, 1),
-         (4, NOW(), null, null, 3);
+INSERT INTO test_runs (id, test_id, started_at, completed_at, pass, region_id)
+  VALUES (100000, 100000, NOW(), NOW(), true, 100000),
+         (100001, 100000, NOW(), NOW(), true, 100001),
+         (100002, 100000, NOW(), NOW(), true, 100002),
+         (100003, 100001, NOW(), NOW(), true, 100000),
+         (100004, 100001, NOW(), null, null, 100002);
 
-INSERT INTO assertion_results (test_run_id, assertion_id, actual_value, pass)
-  VALUES (11, 1, '200', true),
-         (11, 2, '237', true),
-         (12, 1, '200', true),
-         (12, 2, '423', true),
-         (13, 1, '200', true),
-         (13, 2, '96', true),
-         (14, 3, '201', true),
-         (14, 4, '598', true),
-         (14, 5, 'title', true),
-         (14, 6, 'my-test-board', true),
-         (15, 3, '201', true),
-         (15, 4, '329', true),
-         (15, 5, 'title', true),
-         (15, 6, 'my-test-board', true);
+INSERT INTO assertion_results (id, test_run_id, assertion_id, actual_value, pass)
+  VALUES (100000, 100000, 100000, '200', true),
+         (100001, 100000, 100001, '237', true),
+         (100002, 100001, 100000, '200', true),
+         (100003, 100001, 100001, '423', true),
+         (100004, 100002, 100000, '200', true),
+         (100005, 100002, 100001, '96', true),
+         (100006, 100003, 100002, '201', true),
+         (100007, 100003, 100003, '598', true),
+         (100008, 100003, 100004, 'title', true),
+         (100009, 100003, 100005, 'my-test-board', true),
+         (100010, 100004, 100002, '201', true),
+         (100011, 100004, 100003, '329', true),
+         (100012, 100004, 100004, 'title', true),
+         (100013, 100004, 100005, 'my-test-board', true);


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

Specifies ids for each INSERT statement. Uses values greater than 100k to not interfere with normal ids.