### PR TITLE
add rule ARN to tests table; correct data shape sent to EB

### DIFF
--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -2,7 +2,8 @@ const { LOCATION_TO_PRE_PROCESSOR } = require('../constants/aws/locationMappings
 const { createRule, addTargetLambda } = require('../lib/aws/eventBridgeActions');
 const { addNewTest, getTests } = require('../lib/db/query');
 
-const createEventBridgeRule = async (test) => {
+const createEventBridgeRule = async (reqBody) => {
+  const { test } = reqBody;
   let targetResponse;
   try {
     const { RuleArn } = await createRule({
@@ -15,7 +16,7 @@ const createEventBridgeRule = async (test) => {
       ruleName,
       lambdaArn: LOCATION_TO_PRE_PROCESSOR['pre-processing'].arn,
       lambdaName: LOCATION_TO_PRE_PROCESSOR['pre-processing'].title,
-      inputJSON: JSON.stringify(test),
+      inputJSON: JSON.stringify(reqBody),
     });
 
     try {
@@ -32,9 +33,8 @@ const createEventBridgeRule = async (test) => {
 
 const createTest = async (req, res) => {
   try {
-    const { test } = req.body;
-    createEventBridgeRule(test);
-    res.status(201).send(`Test ${test.title} created`);
+    createEventBridgeRule(req.body);
+    res.status(201).send(`Test ${req.body.test.title} created`);
   } catch (err) {
     console.log('Error: ', err);
   }

--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -19,7 +19,7 @@ const createEventBridgeRule = async (test) => {
     });
 
     try {
-      await addNewTest(ruleName, test);
+      await addNewTest(ruleName, RuleArn, test);
     } catch (e) {
       throw new Error('Something went wrong with the database operation. Please try again');
     }

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,7 +25,7 @@ Creates a synthetic test
       "body": {},
       "assertions": {
         "statusCode": {
-          "comparison": "equals",
+          "comparison": "equal_to",
           "target": 200
         },
         "responseTime": {
@@ -35,19 +35,19 @@ Creates a synthetic test
         "headers": [
             {
                 "property": "Content-Type",
-                "comparison": "equals",
+                "comparison": "equal_to",
                 "target": "application json"
             },
             {
                 "property": "Connection",
-                "comparison": "equals",
+                "comparison": "equal_to",
                 "target": "keep-alive"
             }
         ],
         "jsonBody": [
             {
                 "property": "title",
-                "comparison": "equals",
+                "comparison": "equal_to",
                 "target": "Test board #2"
             },
             {

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -1,11 +1,22 @@
 const { dbQuery } = require('./conn');
 
 const comparisonTypeIds = {
-  less_than: 1,
-  greater_than: 2,
-  not_equals: 3,
-  equals: 4,
-  is_not_empty: 7,
+  equal_to: 1,
+  not_equal_to: 2,
+  has_key: 3,
+  not_has_key: 4,
+  has_value: 5,
+  not_has_value: 6,
+  is_empty: 7,
+  is_not_empty: 8,
+  greater_than: 9,
+  less_than: 10,
+  greater_than_or_equal_to: 11,
+  less_than_or_equal_to: 12,
+  contains: 13,
+  not_contains: 14,
+  is_null: 15,
+  is_not_null: 16,
 };
 
 async function addNewTestAssertions(testId, assertions) {
@@ -35,15 +46,23 @@ async function addNewTestAssertions(testId, assertions) {
   return true;
 }
 
-async function addNewTest(ruleName, test) {
+async function addNewTest(ruleName, RuleArn, test) {
   const { minutesBetweenRuns, httpRequest } = test;
   const query = `
-    INSERT INTO tests (name, run_frequency_mins, method, url, status) 
-    VALUES ($1, $2, $3, $4, $5)
+    INSERT INTO tests (name, run_frequency_mins, method, url, status, eb_rule_arn) 
+    VALUES ($1, $2, $3, $4, $5, $6)
     RETURNING id
   `;
 
-  const result = await dbQuery(query, ruleName, minutesBetweenRuns, httpRequest.method, httpRequest.url, 'enabled');
+  const result = await dbQuery(
+    query,
+    ruleName,
+    minutesBetweenRuns,
+    httpRequest.method,
+    httpRequest.url,
+    'enabled',
+    RuleArn,
+  );
 
   if (result.rowCount === 1) {
     const { id: testId } = result.rows[0];


### PR DESCRIPTION
- added rule ARN to new record created in `tests` table
- updated `comparisonTypeIds` hash to agree with db schema
- modified the data shape of the JSON sent to the EB rule to conform with spec.

example of new rule input constant in  EB:


![Screen Shot 2022-07-13 at 2 47 42 PM](https://user-images.githubusercontent.com/72320460/178831450-d6282e65-ec43-4fca-be9b-6a48b8d20e99.jpg)


example of new test record in DB:

```json
[
  {
    "id": 9,
    "name": "tim-test-jul-13-num2-test",
    "run_frequency_mins": 10,
    "method": "GET",
    "url": "https://stark-plains-24612.herokuapp.com/api/persons",
    "headers": null,
    "payload": null,
    "query_params": null,
    "teardown": null,
    "status": "enabled",
    "eb_rule_arn": "arn:aws:events:us-east-1:082057163641:rule/tim-test-jul-13-num2-test",
    "created_at": "2022-07-13 20:17:01.390529",
    "updated_at": null
  }
]

```

Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>