### PR TITLE
add http method table

### DIFF
--- a/lib/aws/eventBridgeActions.js
+++ b/lib/aws/eventBridgeActions.js
@@ -3,9 +3,10 @@ const { ebClient } = require('./eventBridgeClient');
 const { lambdaClient, AddPermissionCommand } = require('./lambdaClient');
 
 const createRule = async ({ name, minutesBetweenRuns }) => {
+  // test
   const params = {
     Name: name,
-    ScheduleExpression: minutesBetweenRuns === 1 ? 'rate(1 minute)' : `rate(${minutesBetweenRuns} minutes)`,
+    ScheduleExpression: String(minutesBetweenRuns) === '1' ? 'rate(1 minute)' : `rate(${minutesBetweenRuns} minutes)`,
     State: 'ENABLED',
   };
 

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -87,7 +87,7 @@ async function getTestDB(testId) {
   const query = `
   SELECT 
   t.name,
-  t.method,
+  h.name,
   t.url,
   r.aws_name AS "region",
   a.type,
@@ -97,6 +97,7 @@ async function getTestDB(testId) {
   a.expected_value,
   ar.pass
 FROM tests t
+  JOIN http_methods h ON h.id = t.method_id
   JOIN test_runs tr ON tr.test_id = t.id
   JOIN regions r ON r.id = tr.region_id
   JOIN assertion_results ar ON ar.test_run_id = tr.id

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -1,5 +1,6 @@
 const { dbQuery } = require('./conn');
 
+// TODO: Move to db lookup
 const comparisonTypeIds = {
   equal_to: 1,
   not_equal_to: 2,
@@ -17,6 +18,16 @@ const comparisonTypeIds = {
   not_contains: 14,
   is_null: 15,
   is_not_null: 16,
+};
+
+// TODO: Move to db lookup
+const httpMethodIds = {
+  GET: 1,
+  POST: 2,
+  PUT: 3,
+  DELETE: 4,
+  PATCH: 5,
+  HEAD: 6,
 };
 
 async function addNewTestAssertions(testId, assertions) {
@@ -49,19 +60,13 @@ async function addNewTestAssertions(testId, assertions) {
 async function addNewTest(ruleName, RuleArn, test) {
   const { minutesBetweenRuns, httpRequest } = test;
   const query = `
-    INSERT INTO tests (name, run_frequency_mins, method, url, status, eb_rule_arn) 
-    VALUES ($1, $2, $3, $4, $5, $6)
+    INSERT INTO tests (name, run_frequency_mins, method_id, url, status, eb_rule_arn) 
+    VALUES ('${ruleName}', '${minutesBetweenRuns}', '${httpMethodIds[httpRequest.method]}', '${httpRequest.url}', 'enabled', '${RuleArn}')
     RETURNING id
   `;
 
   const result = await dbQuery(
     query,
-    ruleName,
-    minutesBetweenRuns,
-    httpRequest.method,
-    httpRequest.url,
-    'enabled',
-    RuleArn,
   );
 
   if (result.rowCount === 1) {

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -2,7 +2,7 @@ CREATE TABLE tests (
   id serial PRIMARY KEY,
   name text NOT NULL UNIQUE,
   run_frequency_mins INT NOT NULL,
-  method INT 
+  method_id INT 
     NOT NULL
     REFERENCES http_methods (id),
   url text NOT NULL,

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,3 +1,9 @@
+CREATE TABLE http_methods (
+  id serial PRIMARY KEY,
+  name text NOT NULL UNIQUE,
+  supported BOOLEAN
+);
+
 CREATE TABLE tests (
   id serial PRIMARY KEY,
   name text NOT NULL UNIQUE,
@@ -112,12 +118,6 @@ CREATE TABLE assertion_results (
   actual_value text NOT NULL,
   pass BOOLEAN NOT NULL
 ); 
-
-CREATE TABLE http_methods (
-  id serial PRIMARY KEY,
-  name text NOT NULL UNIQUE,
-  supported BOOLEAN
-);
 
 -- CREATE TABLE slack_alerts (
 --   id serial PRIMARY KEY,

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -2,7 +2,9 @@ CREATE TABLE tests (
   id serial PRIMARY KEY,
   name text NOT NULL UNIQUE,
   run_frequency_mins INT NOT NULL,
-  method text NOT NULL,
+  method INT 
+    NOT NULL
+    REFERENCES http_methods (id),
   url text NOT NULL,
   headers JSONB,
   payload JSONB,
@@ -110,6 +112,12 @@ CREATE TABLE assertion_results (
   actual_value text NOT NULL,
   pass BOOLEAN NOT NULL
 ); 
+
+CREATE TABLE http_methods (
+  id serial PRIMARY KEY,
+  name text NOT NULL UNIQUE,
+  supported BOOLEAN
+);
 
 -- CREATE TABLE slack_alerts (
 --   id serial PRIMARY KEY,

--- a/sql/teardown.sql
+++ b/sql/teardown.sql
@@ -17,3 +17,5 @@ DROP TABLE alerts;
 DROP TABLE notification_settings;
 
 DROP TABLE tests;
+
+DROP TABLE http_methods;

--- a/sql/test_data.sql
+++ b/sql/test_data.sql
@@ -4,7 +4,7 @@ INSERT INTO http_methods (id, name, supported)
          (3, 'PUT', true),
          (4, 'DELETE', true),
          (5, 'PATCH', false),
-         (6, 'HEAD', false)
+         (6, 'HEAD', false);
 
 INSERT INTO tests (id, name, run_frequency_mins, method_id, url, headers, payload, status, eb_rule_arn)
   VALUES (100000, 'first_get_test', 60, 1, 'https://trellific.corkboard.dev/api/boards','{}','{}', 'RUNNING', 'arn:imfake'),

--- a/sql/test_data.sql
+++ b/sql/test_data.sql
@@ -1,6 +1,14 @@
-INSERT INTO tests (id, name, run_frequency_mins, method, url, headers, payload, status, eb_rule_arn)
-  VALUES (100000, 'first_get_test', 60, 'GET', 'https://trellific.corkboard.dev/api/boards','{}','{}', 'RUNNING', 'arn:imfake'),
-         (100001,'first_post_test', 60, 'POST', 'https://trellific.corkboard.dev/api/boards', '{"Content-Type": "application/json"}', '{"board":{"title":"post-test-board"}}', 'RUNNING', 'arn:imfake');
+INSERT INTO http_methods (id, name, supported)
+  VALUES (1, 'GET', true),
+         (2, 'POST', true),
+         (3, 'PUT', true),
+         (4, 'DELETE', true),
+         (5, 'PATCH', false),
+         (6, 'HEAD', false)
+
+INSERT INTO tests (id, name, run_frequency_mins, method_id, url, headers, payload, status, eb_rule_arn)
+  VALUES (100000, 'first_get_test', 60, 1, 'https://trellific.corkboard.dev/api/boards','{}','{}', 'RUNNING', 'arn:imfake'),
+         (100001,'first_post_test', 60, 2, 'https://trellific.corkboard.dev/api/boards', '{"Content-Type": "application/json"}', '{"board":{"title":"post-test-board"}}', 'RUNNING', 'arn:imfake');
 
 INSERT INTO notification_settings (id, alerts_on_recovery, alerts_on_failure)
   VALUES (100000, false, true),


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

Adds the `http_method` table to the database for: 
* powering the UI dropdown
* normalizing the tests.method column

# Validation
Made the following request from Postman after applying the proposed teardown.sql -> schema.sql -> test_data.sql: 
```
{
    "test": {
        "title": "new-table-test-01",
        "locations": ["us-west-1"],
        "minutesBetweenRuns": "1",
        "type": "API",
        "httpRequest": {
            "method": "POST",
            "url": "https://trellific.corkboard.dev/api/boards",
            "headers": {},
            "body": {
                "board": {
                    "title": "end2end-from-tests-crud04"
                }
            },
            "assertions": {
                "statusCode": {
                    "comparison": "equal_to",
                    "property": "",
                    "target": "200"
                }
            }
        }
    }
}
```

Which resulted in the following row being added to the DB: 

<img width="1192" alt="Screen Shot 2022-07-15 at 3 25 55 PM" src="https://user-images.githubusercontent.com/30358327/179319253-a17df0ed-9f56-43de-8c59-3387fe66f30e.png">

And the following in the preProcessor logs: 
```
2022-07-15T22:30:18.246Z	b3b0316f-a468-4023-a439-b1d7f589ed63	INFO	Message 
{
    "test": {
        "title": "new-table-test-01",
        "locations": [
            "us-west-1"
        ],
        "minutesBetweenRuns": "1",
        "type": "API",
        "httpRequest": {
            "method": "POST",
            "url": "https://trellific.corkboard.dev/api/boards",
            "headers": {},
            "body": {
                "board": {
                    "title": "end2end-from-tests-crud04"
                }
            },
            "assertions": {
                "statusCode": {
                    "comparison": "equal_to",
                    "property": "",
                    "target": "200"
                }
            }
        }
    }
}
```

