### PR TITLE
updated naming + target new rules to new lambda

### DIFF
--- a/constants/aws/locationMappings.js
+++ b/constants/aws/locationMappings.js
@@ -1,6 +1,6 @@
-module.exports.LOCATION_TO_PRE_PROCESSOR = {
-  'pre-processing': {
-    arn: 'arn:aws:lambda:us-east-1:082057163641:function:preProcessor-home',
-    title: 'preProcessor-home',
+module.exports.RULE_TARGET_INFO = {
+  'test-route-packager': {
+    arn: 'arn:aws:lambda:us-east-1:082057163641:function:test-route-packager',
+    title: 'test-route-packager',
   },
 };

--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -1,5 +1,5 @@
 const { validationResult } = require('express-validator');
-const { LOCATION_TO_PRE_PROCESSOR } = require('../constants/aws/locationMappings');
+const { RULE_TARGET_INFO } = require('../constants/aws/locationMappings');
 const { createRule, addTargetLambda, addLambdaPermissions } = require('../lib/aws/eventBridgeActions');
 const { addNewTest, getTests, getTestDB } = require('../lib/db/query');
 
@@ -16,13 +16,13 @@ const createEventBridgeRule = async (reqBody) => {
 
     targetResponse = await addTargetLambda({
       ruleName,
-      lambdaArn: LOCATION_TO_PRE_PROCESSOR['pre-processing'].arn,
-      lambdaName: LOCATION_TO_PRE_PROCESSOR['pre-processing'].title,
+      lambdaArn: RULE_TARGET_INFO['test-route-packager'].arn,
+      lambdaName: RULE_TARGET_INFO['test-route-packager'].title,
       inputJSON: JSON.stringify(reqBody),
     });
 
     permissionsResponse = await addLambdaPermissions({
-      lambdaArn: LOCATION_TO_PRE_PROCESSOR['pre-processing'].arn,
+      lambdaArn: RULE_TARGET_INFO['test-route-packager'].arn,
       ruleArn: RuleArn,
     });
 


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

- Changed some variable naming away from old 'pre-preocessor' name
- Change the ARN for the target destination for the new rule definition

See screenshot for the updated arn and new naming for the "pre-processor" lambda

![2022-07-16_14h49_59](https://user-images.githubusercontent.com/32547845/179368318-f6b9e5ab-bfff-4816-98bc-d848017c7147.png)