### PR TITLE
add assertion type lookup table

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,6 +1,31 @@
+CREATE TABLE assertion_types (
+  id serial PRIMARY KEY,
+  name text NOT NULL UNIQUE,
+  display_name text NOT NULL UNIQUE,
+  supported BOOLEAN
+);
+
 CREATE TABLE http_methods (
   id serial PRIMARY KEY,
   name text NOT NULL UNIQUE,
+  display_name text NOT NULL UNIQUE,
+  supported BOOLEAN
+);
+
+CREATE TABLE comparison_types (
+  id serial PRIMARY KEY,
+  name text NOT NULL UNIQUE,
+  display_name text NOT NULL UNIQUE,
+  symbol text UNIQUE,
+  supported BOOLEAN
+); 
+
+CREATE TABLE regions (
+  id serial PRIMARY KEY,
+  name text NOT NULL UNIQUE,
+  display_name text NOT NULL UNIQUE,
+  aws_name text NOT NULL UNIQUE,
+  flag_url text NOT NULL,
   supported BOOLEAN
 );
 
@@ -50,13 +75,6 @@ CREATE TABLE tests_alerts (
     ON DELETE CASCADE
 );
 
-CREATE TABLE regions (
-  id serial PRIMARY KEY,
-  display_name text NOT NULL,
-  aws_name text NOT NULL,
-  flag_url text NOT NULL
-);
-
 CREATE TABLE test_runs (
   id serial PRIMARY KEY,
   test_id INT
@@ -82,12 +100,6 @@ CREATE TABLE tests_regions (
     NOT NULL
     REFERENCES regions (id)
     ON DELETE CASCADE
-); 
-
-CREATE TABLE comparison_types (
-  id serial PRIMARY KEY,
-  name text NOT NULL,
-  symbol text
 ); 
 
 CREATE TABLE assertions (

--- a/sql/teardown.sql
+++ b/sql/teardown.sql
@@ -19,3 +19,5 @@ DROP TABLE notification_settings;
 DROP TABLE tests;
 
 DROP TABLE http_methods;
+
+DROP TABLE assertion_types;

--- a/sql/test_data.sql
+++ b/sql/test_data.sql
@@ -1,10 +1,58 @@
-INSERT INTO http_methods (id, name, supported)
-  VALUES (1, 'GET', true),
-         (2, 'POST', true),
-         (3, 'PUT', true),
-         (4, 'DELETE', true),
-         (5, 'PATCH', false),
-         (6, 'HEAD', false);
+INSERT INTO assertion_types (id, name, display_name, supported) 
+  VALUES (1, 'response_time', 'Response time', true),
+         (2, 'status_code', 'Status code', true),
+         (3, 'body', 'Body', true),
+         (4, 'headers', 'Headers', true);
+
+INSERT INTO http_methods (id, name, display_name, supported)
+  VALUES (1, 'get', 'GET', true),
+         (2, 'post', 'POST', true),
+         (3, 'put', 'PUT', true),
+         (4, 'delete', 'DELETE', true),
+         (5, 'patch', 'PATCH', false),
+         (6, 'head', 'HEAD', false);
+
+INSERT INTO comparison_types (id, name, display_name, symbol, supported)
+  VALUES (1, 'equal_to', 'Equal to', '=', true),
+         (2, 'not_equal_to', 'Not equal to', '!=', true),
+         (3, 'greater_than', 'Greater than', '>', true),
+         (4, 'less_than', 'Less than', '<', true),
+         (5, 'greater_than_or_equal_to', 'Greater than or equal to', '>=', true),
+         (6, 'less_than_or_equal_to', 'Less than or equal to', '<=', true),
+         (7, 'has_key', 'Has key', null, false),
+         (8, 'not_has_key', 'Not has key', null, false),
+         (9, 'has_value', 'Has value', null, false),
+         (10, 'not_has_value', 'Not has value', null, false),
+         (11, 'is_empty', 'Is empty', null, false),
+         (12, 'is_not_empty', 'Is not empty', null, false),
+         (13, 'contains', 'Contains', null, false),
+         (14, 'not_contains', 'Not contains', null, false),
+         (15, 'is_null', 'Is null', null, false),
+         (16, 'is_not_null', 'Is not null', null, false);
+
+INSERT INTO regions (id, name, display_name, aws_name, flag_url, supported)
+  VALUES (1, 'us_east_1', 'N. Virginia', 'us-east-1','https://countryflagsapi.com/png/usa', true),
+         (2, 'us_east_2','Ohio', 'us-east-2','https://countryflagsapi.com/png/usa', false),
+         (3, 'us_west_1','N. California', 'us-west-1','https://countryflagsapi.com/png/usa', true),
+         (4, 'us_west_2','Oregon', 'us-west-2','https://countryflagsapi.com/png/usa', false),
+         (5, 'ca_central_1','Montreal', 'ca-central-1','https://countryflagsapi.com/png/canada', true),
+         (6, 'sa_east_1','São Paulo', 'sa-east-1','https://countryflagsapi.com/png/brazil', false),
+         (7, 'eu_north_1','Stockholm', 'eu-north-1','https://countryflagsapi.com/png/sweden', true),
+         (8, 'eu_west_3','Paris', 'eu-west-3','https://countryflagsapi.com/png/france', false),
+         (9, 'eu_west_2','London', 'eu-west-2','https://countryflagsapi.com/png/gbr', false),
+         (10, 'eu_west_1','Ireland', 'eu-west-1','https://countryflagsapi.com/png/ireland', false),
+         (11, 'eu_central_1','Frankfurt', 'eu-central-1','https://countryflagsapi.com/png/germany', false),
+         (12, 'eu_south_1','Milan', 'eu-south-1','https://countryflagsapi.com/png/italy', false),
+         (13, 'me_south_1','Bahrain', 'me-south-1','https://countryflagsapi.com/png/bahrain', false),
+         (14, 'af_south_1','Cape Town', 'af-south-1','https://countryflagsapi.com/png/zaf', false),
+         (15, 'ap_southeast_1','Singapore', 'ap-southeast-1','https://countryflagsapi.com/png/singapore', false),
+         (16, 'ap_northeast_1','Tokyo', 'ap-northeast-1','https://countryflagsapi.com/png/japan', false),
+         (17, 'ap_northeast_3','Osaka', 'ap-northeast-3','https://countryflagsapi.com/png/japan', false),
+         (18, 'ap_east_1','Hong Kong', 'ap-east-1','https://countryflagsapi.com/png/china', false),
+         (19, 'ap_southeast_2','Sydney', 'ap-southeast-2','https://countryflagsapi.com/png/australia', false),
+         (20, 'ap_southeast_3','Jakarta', 'ap-southeast-3','https://countryflagsapi.com/png/indonesia', false),
+         (21, 'ap_northeast_2','Seoul', 'ap-northeast-2','https://countryflagsapi.com/png/kor', false),
+         (22, 'ap_south_1','Mumbai', 'ap-south-1','https://countryflagsapi.com/png/india', false);
 
 INSERT INTO tests (id, name, run_frequency_mins, method_id, url, headers, payload, status, eb_rule_arn)
   VALUES (100000, 'first_get_test', 60, 1, 'https://trellific.corkboard.dev/api/boards','{}','{}', 'RUNNING', 'arn:imfake'),
@@ -22,77 +70,27 @@ INSERT INTO tests_alerts (test_id, alerts_id)
   VALUES (100000,100000),
          (100001,100001);
 
-INSERT INTO comparison_types (id, name, symbol)
-  VALUES (100000, 'equal_to', '='),
-         (100001, 'greather_than', '>'),
-         (100002, 'less_than', '<'),
-         (100003, 'greater_than_or_equal_to', '>='),
-         (100004, 'less_than_or_equal_to', '<='),
-         (1, 'equal_to', '='),
-         (2, 'not_equal_to', '!='),
-         (3, 'has_key', null),
-         (4, 'not_has_key', null),
-         (5, 'has_value', null),
-         (6, 'not_has_value', null),
-         (7, 'is_empty', null),
-         (8, 'is_not_empty', null),
-         (9, 'greather_than', '>'),
-         (10, 'less_than', '<'),
-         (11, 'greater_than_or_equal_to', '>='),
-         (12, 'less_than_or_equal_to', '<='),
-         (13, 'contains', null),
-         (14, 'not_contains', null),
-         (15, 'is_null', null),
-         (16, 'is_not_null', null);
-
 INSERT INTO assertions (id, test_id, type, property, comparison_type_id, expected_value)
-  VALUES (100000, 100000, 'status_code', null, 100000, '200'),
-         (100001, 100000, 'response_time_ms', null, 100004, '500'),
-         (100002, 100001, 'status_code', null, 100000, '201'),
-         (100003, 100001, 'response_time_ms', null, 100004, '600'),
-         (100004, 100001, 'contains_property', null, 100000, 'title'),
-         (100005, 100001, 'contains_value','title', 100000, 'my-test-board');
-
-INSERT INTO regions (id, display_name, aws_name, flag_url)
-  VALUES (100000, 'Virginia', 'us-east-1', 'https://img.icons8.com/office/344/usa.png'),
-         (100001, 'Montreal', 'ca-central-1', 'https://img.icons8.com/office/344/canada.png'),
-         (100002, 'Stockholm', 'eu-north-1', 'https://img.icons8.com/offices/344/sweden.png'),
-         (1,'N. Virginia', 'us-east-1','https://countryflagsapi.com/png/usa'),
-         (2,'Ohio', 'us-east-2','https://countryflagsapi.com/png/usa'),
-         (3,'N. California', 'us-west-1','https://countryflagsapi.com/png/usa'),
-         (4,'Oregon', 'us-west-2','https://countryflagsapi.com/png/usa'),
-         (5,'Montreal', 'ca-central-1','https://countryflagsapi.com/png/canada'),
-         (6,'São Paulo', 'sa-east-1','https://countryflagsapi.com/png/brazil'),
-         (7,'Stockholm', 'eu-north-1','https://countryflagsapi.com/png/sweden'),
-         (8,'Paris', 'eu-west-3','https://countryflagsapi.com/png/france'),
-         (9,'London', 'eu-west-2','https://countryflagsapi.com/png/gbr'),
-         (10,'Ireland', 'eu-west-1','https://countryflagsapi.com/png/ireland'),
-         (11,'Frankfurt', 'eu-central-1','https://countryflagsapi.com/png/germany'),
-         (12,'Milan', 'eu-south-1','https://countryflagsapi.com/png/italy'),
-         (13,'Bahrain', 'me-south-1','https://countryflagsapi.com/png/bahrain'),
-         (14,'Cape Town', 'af-south-1','https://countryflagsapi.com/png/zaf'),
-         (15,'Singapore', 'ap-southeast-1','https://countryflagsapi.com/png/singapore'),
-         (16,'Tokyo', 'ap-northeast-1','https://countryflagsapi.com/png/japan'),
-         (17,'Osaka', 'ap-northeast-3','https://countryflagsapi.com/png/japan'),
-         (18,'Hong Kong', 'ap-east-1','https://countryflagsapi.com/png/china'),
-         (19,'Sydney', 'ap-southeast-2','https://countryflagsapi.com/png/australia'),
-         (20,'Jakarta', 'ap-southeast-3','https://countryflagsapi.com/png/indonesia'),
-         (21,'Seoul', 'ap-northeast2','https://countryflagsapi.com/png/kor'),
-         (22,'Mumbai', 'ap-south-1','https://countryflagsapi.com/png/india');
+  VALUES (100000, 100000, 'status_code', null, 1, '200'),
+         (100001, 100000, 'response_time_ms', null, 4, '500'),
+         (100002, 100001, 'status_code', null, 1, '201'),
+         (100003, 100001, 'response_time_ms', null, 4, '600'),
+         (100004, 100001, 'contains_property', null, 1, 'title'),
+         (100005, 100001, 'contains_value','title', 1, 'my-test-board');
          
 INSERT INTO tests_regions (test_id, region_id)
-  VALUES (100000, 100000),
-         (100000, 100001),
-         (100000, 100002),
-         (100001, 100000),
-         (100001, 100002);
+  VALUES (100000, 1),
+         (100000, 2),
+         (100000, 3),
+         (100001, 1),
+         (100001, 3);
 
 INSERT INTO test_runs (id, test_id, started_at, completed_at, pass, region_id)
-  VALUES (100000, 100000, NOW(), NOW(), true, 100000),
-         (100001, 100000, NOW(), NOW(), true, 100001),
-         (100002, 100000, NOW(), NOW(), true, 100002),
-         (100003, 100001, NOW(), NOW(), true, 100000),
-         (100004, 100001, NOW(), null, null, 100002);
+  VALUES (100000, 100000, NOW(), NOW(), true, 1),
+         (100001, 100000, NOW(), NOW(), true, 2),
+         (100002, 100000, NOW(), NOW(), true, 3),
+         (100003, 100001, NOW(), NOW(), true, 1),
+         (100004, 100001, NOW(), null, null, 3);
 
 INSERT INTO assertion_results (id, test_run_id, assertion_id, actual_value, pass)
   VALUES (100000, 100000, 100000, '200', true),


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

There are several changes:
* Remove 100xxx rows from lookup tables as the actual values are unlikely to change
* Add `assertion_types` lookup table
* Make column naming for lookup tables consistent

# Validation 
Migrated to new schema and then created test `new-table-t1`. Initial results populated after a minute or two:

<img width="1240" alt="Screen Shot 2022-07-18 at 6 42 19 PM" src="https://user-images.githubusercontent.com/30358327/179645855-0daf483d-5c3e-4ab7-91f6-3848fd71185a.png">

