### PR TITLE
added sideload endpoint

### DIFF
--- a/controllers/sideloadController.js
+++ b/controllers/sideloadController.js
@@ -1,0 +1,13 @@
+const DB = require('../lib/db/query');
+
+const getSideload = async (req, res) => {
+  try {
+    const data = await DB.getSideload();
+    console.log(res);
+    res.json(data);
+  } catch (err) {
+    console.log('Error: ', err);
+  }
+};
+
+module.exports.getSideload = getSideload;

--- a/controllers/sideloadController.js
+++ b/controllers/sideloadController.js
@@ -3,7 +3,6 @@ const DB = require('../lib/db/query');
 const getSideload = async (req, res) => {
   try {
     const data = await DB.getSideload();
-    console.log(res);
     res.json(data);
   } catch (err) {
     console.log('Error: ', err);

--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -1,7 +1,6 @@
 const { validationResult } = require('express-validator');
 const { RULE_TARGET_INFO } = require('../constants/aws/locationMappings');
 const { createRule, addTargetLambda, addLambdaPermissions } = require('../lib/aws/eventBridgeActions');
-// const { addNewTest, getTests, getTestDB } = require('../lib/db/query');
 const DB = require('../lib/db/query');
 
 const createEventBridgeRule = async (reqBody) => {

--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -1,7 +1,8 @@
 const { validationResult } = require('express-validator');
 const { RULE_TARGET_INFO } = require('../constants/aws/locationMappings');
 const { createRule, addTargetLambda, addLambdaPermissions } = require('../lib/aws/eventBridgeActions');
-const { addNewTest, getTests, getTestDB } = require('../lib/db/query');
+// const { addNewTest, getTests, getTestDB } = require('../lib/db/query');
+const DB = require('../lib/db/query');
 
 const createEventBridgeRule = async (reqBody) => {
   const { test } = reqBody;
@@ -27,7 +28,7 @@ const createEventBridgeRule = async (reqBody) => {
     });
 
     try {
-      await addNewTest(ruleName, RuleArn, test);
+      await DB.addNewTest(ruleName, RuleArn, test);
     } catch (e) {
       throw new Error('Something went wrong with the database operation. Please try again');
     }
@@ -54,7 +55,7 @@ const createTest = async (req, res) => {
 
 const getScheduledTests = async (req, res) => {
   try {
-    const data = await getTests();
+    const data = await DB.getTests();
     res.json(data);
   } catch (err) {
     console.log('Error: ', err);
@@ -64,7 +65,7 @@ const getScheduledTests = async (req, res) => {
 const getTest = async (req, res) => {
   try {
     const testId = req.params.id;
-    const data = await getTestDB(testId);
+    const data = await DB.getTest(testId);
     res.json(data);
   } catch (err) {
     console.log('Error: ', err);

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,8 @@
 
 - [1. API Documentation](#1-api-documentation)
   - [1.1. POST /api/tests](#14-post-apitests)
+  - [1.2. GET /api/tests](#79-post-apitests)
+  - [1.3. GET /tests/:id](#138-post-apitests)
 
 ## 1.1. POST /api/tests
 
@@ -74,3 +76,123 @@ Test my-new-test created
 #### 1.1.3 Forwarded Payload
 
 The payload received from the client (refer to 1.1.1) is forwarded to EventBridge for use as the "Input to Target" JSON without modification.
+
+
+## 1.2. GET /api/tests
+
+Get all scheduled test
+
+### 1.2.1. Expected Payload
+
+no payload
+
+### 1.2.2. Successful Response
+
+The scheduled tests are returned in JSON format with a 200 response status code.
+
+#### 1.2.2.1. Example Response
+
+```json
+[
+  {
+    "id": 100000,
+    "name": "first_get_test",
+    "run_frequency_mins": 60,
+    "method": "GET",
+    "url": "https://example.com/api/endpoint",
+    "headers": {},
+    "payload": {},
+    "query_params": null,
+    "teardown": null,
+    "status": "RUNNING",
+    "eb_rule_arn": "arn:imfake",
+    "created_at": "2022-07-15T20:43:18.001Z",
+    "updated_at": null
+  },
+  {
+    "id": 100001,
+    "name": "first_post_test",
+    "run_frequency_mins": 60,
+    "method": "POST",
+    "url": "https://example.com/api/endpoint",
+    "headers": {
+        "Content-Type": "application/json"
+    },
+    "payload": {
+        "board": {
+            "title": "post-test-board"
+        }
+    },
+    "query_params": null,
+    "teardown": null,
+    "status": "RUNNING",
+    "eb_rule_arn": "arn:imfake",
+    "created_at": "2022-07-15T20:43:18.001Z",
+    "updated_at": null
+  }
+]
+```
+
+#### 1.2.3 Forwarded Payload
+
+none
+
+## 1.3. GET /api/tests
+
+Get all runs for a single test
+
+### 1.3.1. Expected Payload
+
+no payload
+
+### 1.3.2. Successful Response
+
+The tests runs are returned in JSON format with a 200 response status code.
+
+#### 1.3.2.1. Example Response
+
+```json
+[
+  {
+    "name": "first_get_test",
+    "method": "GET",
+    "url": "https://trellific.corkboard.dev/api/boards",
+    "region": "us-east-1",
+    "type": "response_time_ms",
+    "property": null,
+    "actual_value": "237",
+    "comparison_type": "<=",
+    "expected_value": "500",
+    "pass": true
+  },
+  {
+    "name": "first_get_test",
+    "method": "GET",
+    "url": "https://trellific.corkboard.dev/api/boards",
+    "region": "ca-central-1",
+    "type": "response_time_ms",
+    "property": null,
+    "actual_value": "423",
+    "comparison_type": "<=",
+    "expected_value": "500",
+    "pass": false
+  },
+  {
+    "name": "first_get_test",
+    "method": "GET",
+    "url": "https://trellific.corkboard.dev/api/boards",
+    "region": "ca-central-1",
+    "type": "status_code",
+    "property": null,
+    "actual_value": "200",
+    "comparison_type": "=",
+    "expected_value": "200",
+    "pass": true
+  },
+]
+
+```
+
+#### 1.3.3 Forwarded Payload
+
+none

--- a/docs/api.md
+++ b/docs/api.md
@@ -138,7 +138,7 @@ The scheduled tests are returned in JSON format with a 200 response status code.
 
 none
 
-## 1.3. GET /api/test/:id
+## 1.3. GET /api/tests/:id
 
 Get all runs for a single test
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -196,3 +196,89 @@ The tests runs are returned in JSON format with a 200 response status code.
 #### 1.3.3 Forwarded Payload
 
 none
+
+## 1.3. GET /api/sideload
+
+Get sideload data 
+
+### 1.3.1. Expected Payload
+
+no payload
+
+### 1.3.2. Successful Response
+
+The tests runs are returned in JSON format with a 200 response status code.
+
+#### 1.3.2.1. Example Response
+
+```json
+{
+  "comparisonTypes": [
+    {
+      "id": 1,
+      "name": "equal_to",
+      "display_name": "Equal to",
+      "symbol": "=",
+      "supported": true
+    },
+    {
+      "id": 2,
+      "name": "not_equal_to",
+      "display_name": "Not equal to",
+      "symbol": "!=",
+      "supported": true
+    },
+  ],
+  "regions": [
+    {
+      "id": 1,
+      "name": "us_east_1",
+      "display_name": "N. Virginia",
+      "aws_name": "us-east-1",
+      "flag_url": "https://countryflagsapi.com/png/usa",
+      "supported": true
+    },
+    {
+      "id": 2,
+      "name": "us_east_2",
+      "display_name": "Ohio",
+      "aws_name": "us-east-2",
+      "flag_url": "https://countryflagsapi.com/png/usa",
+      "supported": false
+    },
+  ],
+  "httpsMethod": [
+    {
+      "id": 1,
+      "name": "get",
+      "display_name": "GET",
+      "supported": true
+    },
+    {
+      "id": 2,
+      "name": "post",
+      "display_name": "POST",
+      "supported": true
+    },
+  ],
+  "assertionTypesResult": [
+    {
+      "id": 1,
+      "name": "response_time",
+      "display_name": "Response time",
+      "supported": true
+    },
+    {
+      "id": 2,
+      "name": "status_code",
+      "display_name": "Status code",
+      "supported": true
+    },
+  ]
+}
+
+```
+
+#### 1.3.3 Forwarded Payload
+
+none

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,8 +2,9 @@
 
 - [1. API Documentation](#1-api-documentation)
   - [1.1. POST /api/tests](#14-post-apitests)
-  - [1.2. GET /api/tests](#79-post-apitests)
-  - [1.3. GET /tests/:id](#138-post-apitests)
+  - [1.2. GET /api/tests](#79-get-apitests)
+  - [1.3. GET /api/tests/:id](#138-get-apitest)
+	- [1.4. GET /api/sideload](#201-get-apitest)
 
 ## 1.1. POST /api/tests
 
@@ -137,7 +138,7 @@ The scheduled tests are returned in JSON format with a 200 response status code.
 
 none
 
-## 1.3. GET /api/tests
+## 1.3. GET /api/test/:id
 
 Get all runs for a single test
 
@@ -197,19 +198,19 @@ The tests runs are returned in JSON format with a 200 response status code.
 
 none
 
-## 1.3. GET /api/sideload
+## 1.4.0 GET /api/sideload
 
 Get sideload data 
 
-### 1.3.1. Expected Payload
+### 1.4.1. Expected Payload
 
 no payload
 
-### 1.3.2. Successful Response
+### 1.4.2. Successful Response
 
 The tests runs are returned in JSON format with a 200 response status code.
 
-#### 1.3.2.1. Example Response
+#### 1.4.2.1. Example Response
 
 ```json
 {
@@ -279,6 +280,6 @@ The tests runs are returned in JSON format with a 200 response status code.
 
 ```
 
-#### 1.3.3 Forwarded Payload
+#### 1.4.3 Forwarded Payload
 
 none

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -83,7 +83,7 @@ async function getTests() {
   return result.rows;
 }
 
-async function getTestDB(testId) {
+async function getTest(testId) {
   const query = `
   SELECT 
   t.name,
@@ -110,8 +110,28 @@ WHERE t.id = ${testId}
   return result.rows;
 }
 
-module.exports = {
-  addNewTest,
-  getTests,
-  getTestDB,
-};
+async function getSideload() {
+  const regionsQuery = 'SELECT * FROM regions;';
+
+  const comparisonTypesQuery = 'SELECT * FROM comparison_types;';
+
+  const methodQuery = 'SELECT * FROM http_methods WHERE supported=true;';
+  const assertinTypesQuery = 'SELECT * FROM assertion_types;'
+
+  const regionsResult = await dbQuery(regionsQuery);
+  const coparisonTypesResult = await dbQuery(comparisonTypesQuery);
+  const methodQueryResult = await dbQuery(methodQuery);
+  const assertionTypesResult = await dbQuery(assertinTypesQuery);
+
+  return {
+    comparisonTypes: coparisonTypesResult.rows,
+    regions: regionsResult.rows,
+    httpsMethod: methodQueryResult.rows,
+    assertionTypes: assertionTypesResult.rows
+  };
+}
+
+module.exports.addNewTest = addNewTest;
+module.exports.getTests = getTests;
+module.exports.getTest = getTest;
+module.exports.getSideload = getSideload;

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -112,11 +112,9 @@ WHERE t.id = ${testId}
 
 async function getSideload() {
   const regionsQuery = 'SELECT * FROM regions;';
-
   const comparisonTypesQuery = 'SELECT * FROM comparison_types;';
-
   const methodQuery = 'SELECT * FROM http_methods WHERE supported=true;';
-  const assertinTypesQuery = 'SELECT * FROM assertion_types;'
+  const assertinTypesQuery = 'SELECT * FROM assertion_types;';
 
   const regionsResult = await dbQuery(regionsQuery);
   const coparisonTypesResult = await dbQuery(comparisonTypesQuery);
@@ -126,8 +124,8 @@ async function getSideload() {
   return {
     comparisonTypes: coparisonTypesResult.rows,
     regions: regionsResult.rows,
-    httpsMethods: methodQueryResult.rows,
-    assertionTypes: assertionTypesResult.rows
+    httpMethods: methodQueryResult.rows,
+    assertionTypes: assertionTypesResult.rows,
   };
 }
 

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -126,7 +126,7 @@ async function getSideload() {
   return {
     comparisonTypes: coparisonTypesResult.rows,
     regions: regionsResult.rows,
-    httpsMethod: methodQueryResult.rows,
+    httpsMethods: methodQueryResult.rows,
     assertionTypes: assertionTypesResult.rows
   };
 }

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const testsController = require('../controllers/testsController');
+const sideloadController = require('../controllers/sideloadController');
 const { validateTest } = require('../validators/test');
 
 const router = express.Router();
@@ -7,5 +8,6 @@ const router = express.Router();
 router.post('/tests', validateTest, testsController.createTest);
 router.get('/tests', testsController.getScheduledTests);
 router.get('/tests/:id', testsController.getTest);
+router.get('/sideload', sideloadController.getSideload);
 
 module.exports = router;


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>

- created an endpoint for `GET` `/sideload`. The response contains a JSON file with data for `comparisonTypes`,  `regions`, `httpsMethods` and `assertionTypes`. 
- updated documentation for `GET /tests`, `GET tests/:id` and `GET /sideload` 
- changed the file exporting way for better naming of functions:  
Exporting: 
```javascript
module.exports.addNewTest = addNewTest;
module.exports.getTests = getTests;
module.exports.getTest = getTest;
module.exports.getSideload = getSideload;
```
Requireing: 
```javascript
const DB = require('../lib/db/query');
```
Using: 
```javascript
 await DB.addNewTest(ruleName, RuleArn, test);
```


    