### PR TITLE
make assertion results column nullable

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -127,7 +127,7 @@ CREATE TABLE assertion_results (
     NOT NULL
     REFERENCES assertions (id)
     ON DELETE CASCADE,
-  actual_value text NOT NULL,
+  actual_value text,
   pass BOOLEAN NOT NULL
 ); 
 

--- a/sql/test_data.sql
+++ b/sql/test_data.sql
@@ -106,4 +106,5 @@ INSERT INTO assertion_results (id, test_run_id, assertion_id, actual_value, pass
          (100010, 100004, 100002, '201', true),
          (100011, 100004, 100003, '329', true),
          (100012, 100004, 100004, 'title', true),
-         (100013, 100004, 100005, 'my-test-board', true);
+         (100013, 100004, 100005, 'my-test-board', true),
+         (100014, 100004, 100004, null, true);


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

Allow NULL values for `assertion_results.actual_value` since some assertion types (e.g. has header value: xyz) don't imply an actual value in the case that the assertion fails

# Validation 
Ran the following successfully: 
* `ALTER TABLE assertion_results ALTER COLUMN actual_value DROP NOT NULL`
* `INSERT INTO assertion_results (id, test_run_id, assertion_id, actual_value, pass) VALUES (100014, 100004, 100004, null, true)`