### PR TITLE
adding run now endpoint that trigger test-route-packager directly

### DIFF
--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -1,3 +1,4 @@
+const axios = require('axios');
 const { validationResult } = require('express-validator');
 const { RULE_TARGET_INFO } = require('../constants/aws/locationMappings');
 const { createRule, addTargetLambda, addLambdaPermissions } = require('../lib/aws/eventBridgeActions');
@@ -71,6 +72,20 @@ const getTest = async (req, res) => {
   }
 };
 
+const runNow = async (req, res) => {
+  try {
+    const testId = req.params.id;
+    // this url will need to come from a config file
+    const lambdaURL = 'https://x3a5z6dcrihrt5dzirl3c6lube0wrlys.lambda-url.us-east-1.on.aws/';
+    const data = await DB.getTestBody(testId);
+    axios.post(lambdaURL, data);
+    res.status(200).send('Run now successful');
+  } catch (err) {
+    console.log('Error: ', err);
+  }
+};
+
+exports.runNow = runNow;
 exports.createTest = createTest;
 exports.getScheduledTests = getScheduledTests;
 exports.getTest = getTest;

--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -79,7 +79,7 @@ const runNow = async (req, res) => {
     const lambdaURL = 'https://x3a5z6dcrihrt5dzirl3c6lube0wrlys.lambda-url.us-east-1.on.aws/';
     const data = await DB.getTestBody(testId);
     axios.post(lambdaURL, data);
-    res.status(200).send('Run now successful');
+    res.status(200).send('Send single run succesful');
   } catch (err) {
     console.log('Error: ', err);
   }

--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -79,7 +79,7 @@ const runNow = async (req, res) => {
     const lambdaURL = 'https://x3a5z6dcrihrt5dzirl3c6lube0wrlys.lambda-url.us-east-1.on.aws/';
     const data = await DB.getTestBody(testId);
     axios.post(lambdaURL, data);
-    res.status(200).send('Send single run succesful');
+    res.status(200).send('OK');
   } catch (err) {
     console.log('Error: ', err);
   }

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,8 @@
   - [1.1. POST /api/tests](#14-post-apitests)
   - [1.2. GET /api/tests](#79-get-apitests)
   - [1.3. GET /api/tests/:id](#138-get-apitest)
-	- [1.4. GET /api/sideload](#201-get-apitest)
+	- [1.4. GET /api/sideload](#201-get-sideload)
+	- [1.5. GET /api/tests/run/:id](#298-get-apitestrun)
 
 ## 1.1. POST /api/tests
 
@@ -293,3 +294,53 @@ The tests runs are returned in JSON format with a 200 response status code.
 #### 1.4.3 Forwarded Payload
 
 none
+
+## 1.5.0 GET /api/tests/run/:id
+
+Run single test run
+
+### 1.5.1. Expected Payload
+
+no payload
+
+### 1.5.2. Successful Response
+
+200 response status code.
+
+#### 1.5.2.1. Example Response
+
+200 OK
+
+#### 1.5.3 Forwarded Payload
+```json
+{
+    "test": {
+        "title": "example-title",
+        "locations": [
+            "us-west-1"
+        ],
+        "minutesBetweenRuns": 1,
+        "type": "API",
+        "httpRequest": {
+            "method": "GET",
+            "url": "https://example-website.com",
+            "headers": null,
+            "body": null,
+            "assertions": {
+                "headers": [
+                    {
+                        "property": "access-control-allow-origin",
+                        "target": "*",
+                        "comparison": "equal_to"
+                    },
+                    {
+                        "property": "connection",
+                        "target": "closed",
+                        "comparison": "equal_to"
+                    }
+                ]
+            }
+        }
+    }
+}
+```

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -178,7 +178,7 @@ async function getTestBody(testId) {
       minutesBetweenRuns: frequency,
       type: 'API',
       httpRequest: {
-        method,
+        method: method.toUpperCase(),
         url,
         headers,
         body,

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -149,7 +149,7 @@ async function getTestBody(testId) {
    a.type,
    a.property,
    a.expected_value,
-   ct.name
+   ct.name as comparison
   FROM assertions a
     JOIN comparison_types ct
     ON a.comparison_type_id = ct.id
@@ -182,11 +182,10 @@ async function getTestBody(testId) {
         url,
         headers,
         body,
-        assertions: helpers.toCamelCase(assertions.rows, 'type'),
+        assertions: helpers.formatAssertions(assertions.rows),
       },
     },
   };
-
   return json;
 }
 

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -1,4 +1,5 @@
 const { dbQuery } = require('./conn');
+const helpers = require('../../utils/helpers');
 
 // TODO: Move to db lookup
 const comparisonTypeIds = {
@@ -129,7 +130,68 @@ async function getSideload() {
   };
 }
 
+async function getTestBody(testId) {
+  const query1 = `
+  SELECT 
+    t.name,
+    t.run_frequency_mins as frequency,
+    t.headers,
+    t.payload as body,
+    t.url,
+    hp.name as method
+  FROM tests t
+    JOIN http_methods hp ON hp.id = t.method_id 
+    WHERE t.id = ${testId};
+  `;
+
+  const query2 = `
+  SELECT 
+   a.type,
+   a.property,
+   a.expected_value,
+   ct.name
+  FROM assertions a
+    JOIN comparison_types ct
+    ON a.comparison_type_id = ct.id
+    WHERE a.test_id = ${testId};
+   `;
+
+  const query3 = `
+    SELECT 
+      DISTINCT r.name
+    FROM regions r
+      JOIN test_runs tr ON r.id = tr.region_id
+      WHERE tr.test_id = ${testId};
+    `;
+
+  const testCofnig = await dbQuery(query1);
+  const assertions = await dbQuery(query2);
+  const locations = await dbQuery(query3);
+
+  // eslint-disable-next-line object-curly-newline
+  const { name, frequency, headers, body, url, method } = testCofnig.rows[0];
+
+  const json = {
+    test: {
+      title: name,
+      locations: locations.rows.map((obj) => helpers.toDash(obj.name)),
+      minutesBetweenRuns: frequency,
+      type: 'API',
+      httpRequest: {
+        method,
+        url,
+        headers,
+        body,
+        assertions: helpers.toCamelCase(assertions.rows, 'type'),
+      },
+    },
+  };
+
+  return json;
+}
+
 module.exports.addNewTest = addNewTest;
 module.exports.getTests = getTests;
 module.exports.getTest = getTest;
 module.exports.getSideload = getSideload;
+module.exports.getTestBody = getTestBody;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-eventbridge": "^3.121.0",
         "@aws-sdk/client-lambda": "^3.130.0",
         "aws-sdk": "^2.1169.0",
+        "axios": "^0.27.2",
         "cors": "^2.8.5",
         "dotenv": "^16.0.1",
         "express": "^4.18.1",
@@ -1930,6 +1931,11 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/aws-sdk": {
       "version": "2.1170.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1170.0.tgz",
@@ -1957,6 +1963,15 @@
       "peer": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2179,6 +2194,17 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2296,6 +2322,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -3077,6 +3111,38 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -6530,6 +6596,11 @@
       "dev": true,
       "peer": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "aws-sdk": {
       "version": "2.1170.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1170.0.tgz",
@@ -6552,6 +6623,15 @@
       "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
       "dev": true,
       "peer": true
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -6713,6 +6793,14 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6805,6 +6893,11 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -7413,6 +7506,21 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "forwarded": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@aws-sdk/client-eventbridge": "^3.121.0",
     "@aws-sdk/client-lambda": "^3.130.0",
     "aws-sdk": "^2.1169.0",
+    "axios": "^0.27.2",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",

--- a/routes/api.js
+++ b/routes/api.js
@@ -9,5 +9,6 @@ router.post('/tests', validateTest, testsController.createTest);
 router.get('/tests', testsController.getScheduledTests);
 router.get('/tests/:id', testsController.getTest);
 router.get('/sideload', sideloadController.getSideload);
+router.get('/tests/run/:id', testsController.runNow);
 
 module.exports = router;

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,0 +1,24 @@
+/* eslint-disable arrow-body-style */
+const snakeToCamel = (str) => {
+  return str.toLowerCase().replace(/([-_][a-z])/g, (group) => {
+    return group
+      .toUpperCase()
+      .replace('-', '')
+      .replace('_', '');
+  });
+};
+
+const toCamelCase = (data, prop) => {
+  return data.map((item) => {
+    return { ...item, [prop]: snakeToCamel(item[prop]) };
+  });
+};
+
+const toDash = (str) => {
+  const RE = /_/g;
+  return str.replace(RE, '-');
+};
+
+module.exports.snakeToCamel = snakeToCamel;
+module.exports.toCamelCase = toCamelCase;
+module.exports.toDash = toDash;

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 /* eslint-disable arrow-body-style */
 const snakeToCamel = (str) => {
   return str.toLowerCase().replace(/([-_][a-z])/g, (group) => {
@@ -19,6 +20,30 @@ const toDash = (str) => {
   return str.replace(RE, '-');
 };
 
+const formatAssertions = (assertionsArr) => {
+  console.log('assertionsArr', assertionsArr);
+  const headers = [];
+
+  return assertionsArr.reduce((prev, curr) => {
+    if (curr.type === 'headers') {
+      headers.push({
+        property: curr.property,
+        target: curr.expected_value,
+        comparison: curr.comparison,
+      });
+      prev[curr.type] = headers;
+    } else {
+      prev[curr.type] = {
+        property: curr.property,
+        target: curr.expected_value,
+        comparison: curr.comparison,
+      };
+    }
+    return prev;
+  }, {});
+};
+
 module.exports.snakeToCamel = snakeToCamel;
 module.exports.toCamelCase = toCamelCase;
 module.exports.toDash = toDash;
+module.exports.formatAssertions = formatAssertions;


### PR DESCRIPTION
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>

- added a new endpoint to trigger a one-time test run `GET /api/tests/run/:id`
- the endpoint queries data and constructs a JSON body and then invokes the lambda function directly and passes the JSON as a body
- the function is invoked with the use of URL only. It bypasses the EventBridge.
- created utils directory with helper functions 
- added function to format assertion array to object
- changed method to upper case
- updated documentation