### PR TITLE
adding columns to test_runs table

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -87,7 +87,11 @@ CREATE TABLE test_runs (
   region_id INT
     NOT NULL
     REFERENCES regions (id)
-    ON DELETE CASCADE
+    ON DELETE CASCADE,
+  response_status TEXT,
+  response_time TEXT,
+  response_body JSONB,
+  response_headers JSONB
 ); 
 
 CREATE TABLE tests_regions (


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>

added the following columns to the `test_runs` table in `schema.sql`:

- `response_status` text
- `response_time` text
- `response_body` jsonb
- `response_headers` jsonb