### PR TITLE
added GET /tests/:id/runs endpoint

### DIFF
--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -85,7 +85,18 @@ const runNow = async (req, res) => {
   }
 };
 
+const getTestRuns = async (req, res) => {
+  try {
+    const testId = req.params.id;
+    const data = await DB.getTestsRuns(testId);
+    res.status(200).json(data);
+  } catch (err) {
+    console.log('Error: ', err);
+  }
+};
+
 exports.runNow = runNow;
 exports.createTest = createTest;
 exports.getScheduledTests = getScheduledTests;
 exports.getTest = getTest;
+exports.getTestRuns = getTestRuns;

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -189,8 +189,62 @@ async function getTestBody(testId) {
   return json;
 }
 
+async function getTestsRuns(id) {
+  const testsQuery = `
+    SELECT 
+    t.name,
+    t.url,
+    t.created_at,
+    t.updated_at,
+    hm.display_name
+    FROM tests t
+    JOIN http_methods hm ON hm.id = t.method_id
+    WHERE t.id = ${id};`;
+
+  const runsQuery = `
+    SELECT DISTINCT
+      tr.id test_run_id,
+      r.id region_id,
+      r.display_name,
+      r.flag_url,
+      tr.pass,
+      tr.started_at,
+      tr.completed_at,
+      EXTRACT(EPOCH FROM (tr.completed_at - tr.started_at)) AS difference
+    FROM test_runs tr
+     JOIN assertion_results ar ON tr.id = ar.test_run_id
+     JOIN regions r ON tr.region_id = r.id
+     WHERE tr.test_id = ${id}`;
+
+  const assertionsResultsQuery = `
+    SELECT
+     tr.id test_run_id, 
+     ar.pass,
+     ar.id assertion_id
+    FROM assertion_results ar
+    JOIN test_runs tr ON ar.test_run_id = tr.id
+    WHERE tr.test_id = ${id};
+  `;
+
+  const tests = await dbQuery(testsQuery);
+  const runs = await dbQuery(runsQuery);
+  const assertionResults = await dbQuery(assertionsResultsQuery);
+
+  const json = {
+    name: tests.rows[0].name || null,
+    method: tests.rows[0].display_name || null,
+    url: tests.rows[0].url || null,
+    createdAt: tests.rows[0].created_at,
+    updatedAt: tests.rows ? tests.rows[0].updated_at : null,
+    runs: helpers.formatRuns(runs.rows, assertionResults.rows),
+  };
+
+  return json;
+}
+
 module.exports.addNewTest = addNewTest;
 module.exports.getTests = getTests;
 module.exports.getTest = getTest;
 module.exports.getSideload = getSideload;
 module.exports.getTestBody = getTestBody;
+module.exports.getTestsRuns = getTestsRuns;

--- a/routes/api.js
+++ b/routes/api.js
@@ -10,5 +10,6 @@ router.get('/tests', testsController.getScheduledTests);
 router.get('/tests/:id', testsController.getTest);
 router.get('/sideload', sideloadController.getSideload);
 router.get('/tests/run/:id', testsController.runNow);
+router.get('/tests/:id/runs', testsController.getTestRuns);
 
 module.exports = router;

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -43,7 +43,37 @@ const formatAssertions = (assertionsArr) => {
   }, {});
 };
 
+const countAssertions = (runId, assertionResults) => {
+  return assertionResults.filter((result) => result.test_run_id === runId).length;
+};
+
+const countAssertionPassed = (runId, assertionResults) => {
+  return assertionResults.filter((result) => {
+    return result.test_run_id === runId && result.pass === true;
+  }).length;
+};
+
+const formatRuns = (runs, assertionResults) => {
+  const testRuns = runs.map((run) => {
+    return {
+      id: run.test_run_id,
+      location: run.display_name,
+      success: run.pass,
+      responseTimeMs: run.difference,
+      assertions: countAssertions(run.test_run_id, assertionResults),
+      assertionsPassed: countAssertionPassed(run.test_run_id, assertionResults),
+      region: {
+        id: run.region_id,
+        flagUrl: run.flag_url,
+      },
+    };
+  });
+
+  return testRuns;
+};
+
 module.exports.snakeToCamel = snakeToCamel;
 module.exports.toCamelCase = toCamelCase;
 module.exports.toDash = toDash;
 module.exports.formatAssertions = formatAssertions;
+module.exports.formatRuns = formatRuns;


### PR DESCRIPTION
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>

This PR: 
- creates an endpoint `GET /tests/:id/runs`
- makes a few queries and modifies the JSON format
- - the current format looks like this:  
```json
{
    "name": "new-endpoint-01",
    "method": "GET",
    "url": "https://trellific.corkboard.dev/api/boards",
    "createdAt": "2022-07-25T10:47:21.336Z",
    "updatedAt": null,
    "runs": [
        {
            "id": 777,
            "location": "N. California",
            "success": null,
            "responseTimeMs": 0,
            "assertions": 3,
            "assertionsPassed": 0,
            "region": {
                "id": 3,
                "flagUrl": "https://countryflagsapi.com/png/usa"
            }
        },
        {
            "id": 778,
            "location": "N. California",
            "success": null,
            "responseTimeMs": 0,
            "assertions": 2,
            "assertionsPassed": 0,
            "region": {
                "id": 3,
                "flagUrl": "https://countryflagsapi.com/png/usa"
            }
        },
    ]
}
```

Few notes: 
- currently the both timestamps for `completed_at` and `started_at` ar exactly the same, therefore the `responseTimeMs` has value `0`. 
- `pass` property for `test_runs` has value of `false` even though it should be `true`. 
That is something I can have a look outside of this PR.