### PR TITLE
updated docs and changed endpoint from GET /run/:id to POST /:id/run

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -5,7 +5,9 @@
   - [1.2. GET /api/tests](#79-get-apitests)
   - [1.3. GET /api/tests/:id](#138-get-apitest)
 	- [1.4. GET /api/sideload](#201-get-sideload)
-	- [1.5. GET /api/tests/run/:id](#298-get-apitestrun)
+	- [1.5. POST /api/tests/:id/run](#298-post-apitestrun)
+	- [1.6. GET /api/tests/:id/run](#304-get-apitestruns)
+
 
 ## 1.1. POST /api/tests
 
@@ -232,14 +234,14 @@ The tests runs are returned in JSON format with a 200 response status code.
   "comparisonTypes": [
     {
       "id": 1,
-      "name": "equal_to",
+      "name": "equalTo",
       "display_name": "Equal to",
       "symbol": "=",
       "supported": true
     },
     {
       "id": 2,
-      "name": "not_equal_to",
+      "name": "notEqualTo",
       "display_name": "Not equal to",
       "symbol": "!=",
       "supported": true
@@ -248,7 +250,7 @@ The tests runs are returned in JSON format with a 200 response status code.
   "regions": [
     {
       "id": 1,
-      "name": "us_east_1",
+      "name": "usEast1",
       "display_name": "N. Virginia",
       "aws_name": "us-east-1",
       "flag_url": "https://countryflagsapi.com/png/usa",
@@ -256,7 +258,7 @@ The tests runs are returned in JSON format with a 200 response status code.
     },
     {
       "id": 2,
-      "name": "us_east_2",
+      "name": "usEast2",
       "display_name": "Ohio",
       "aws_name": "us-east-2",
       "flag_url": "https://countryflagsapi.com/png/usa",
@@ -280,13 +282,13 @@ The tests runs are returned in JSON format with a 200 response status code.
   "assertionTypesResult": [
     {
       "id": 1,
-      "name": "response_time",
+      "name": "responseTime",
       "display_name": "Response time",
       "supported": true
     },
     {
       "id": 2,
-      "name": "status_code",
+      "name": "statusCode",
       "display_name": "Status code",
       "supported": true
     },
@@ -299,7 +301,7 @@ The tests runs are returned in JSON format with a 200 response status code.
 
 none
 
-## 1.5.0 GET /api/tests/run/:id
+## 1.5.0 POST /api/tests/:id/run
 
 Run single test run
 
@@ -348,3 +350,81 @@ no payload
     }
 }
 ```
+
+## 1.5.0 GET /api/tests/:id/runs
+
+Get test runs for a single test
+
+### 1.5.1. Expected Payload
+
+no payload
+
+### 1.5.2. Successful Response
+
+200
+
+#### 1.5.2.1. Example Response
+
+```json
+{
+    "name": "example-title",
+    "method": "GET",
+    "url": "https://example-website.com",
+    "createdAt": "2022-07-25T10:47:21.336Z",
+    "updatedAt": null,
+    "runs": [
+        {
+            "id": 777,
+            "location": "N. California",
+            "success": true,
+            "responseTimeMs": 1234,
+            "assertions": 3,
+            "assertionsPassed": 3,
+            "region": {
+                "id": 3,
+                "flagUrl": "https://countryflagsapi.com/png/usa"
+            }
+        },
+        {
+            "id": 778,
+            "location": "N. California",
+            "success": false,
+            "responseTimeMs": 2341,
+            "assertions": 2,
+            "assertionsPassed": 0,
+            "region": {
+                "id": 3,
+                "flagUrl": "https://countryflagsapi.com/png/usa"
+            }
+        },
+        {
+            "id": 780,
+            "location": "N. Virginia",
+            "success": true,
+            "responseTimeMs": 3241,
+            "assertions": 1,
+            "assertionsPassed": 1,
+            "region": {
+                "id": 1,
+                "flagUrl": "https://countryflagsapi.com/png/usa"
+            }
+        },
+        {
+            "id": 781,
+            "location": "N. California",
+            "success": false,
+            "responseTimeMs": 1234,
+            "assertions": 1,
+            "assertionsPassed": 0,
+            "region": {
+                "id": 3,
+                "flagUrl": "https://countryflagsapi.com/png/usa"
+            }
+        },
+    ]
+}
+```
+
+#### 1.5.3 Forwarded Payload
+
+no payload

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,8 +2,8 @@
 
 - [1. API Documentation](#1-api-documentation)
   - [1.1. POST /api/tests](#14-post-apitests)
-  - [1.2. GET /api/tests](#79-get-apitests)
-  - [1.3. GET /api/tests/:id](#138-get-apitest)
+  - [1.2. GET /api/tests](#99-get-apitests)
+  - [1.3. GET /api/tests/:id](#158-get-apitest)
 	- [1.4. GET /api/sideload](#201-get-sideload)
 	- [1.5. POST /api/tests/:id/run](#298-post-apitestrun)
 	- [1.6. GET /api/tests/:id/run](#304-get-apitestruns)
@@ -118,11 +118,11 @@ The scheduled tests are returned in JSON format with a 200 response status code.
     "run_frequency_mins": 60,
     "method": "GET",
     "url": "https://example.com/api/endpoint",
-    "headers": {},
-    "payload": {},
+    "headers": null,
+    "payload": null,
     "query_params": null,
     "teardown": null,
-    "status": "RUNNING",
+    "status": "enabled",
     "eb_rule_arn": "arn:imfake",
     "created_at": "2022-07-15T20:43:18.001Z",
     "updated_at": null
@@ -171,36 +171,34 @@ The tests runs are returned in JSON format with a 200 response status code.
 
 ```json
 [
+	{
+			"name": "example-test-name1",
+			"url": "https://example-website.com",
+			"region": "us-west-1",
+			"type": "statusCode",
+			"property": null,
+			"actual_value": "200",
+			"comparison_type": "=",
+			"expected_value": "200",
+			"pass": false
+	}
+	{
+			"name": "example-test-name2",
+			"url": "https://example-website.com",
+			"region": "us-west-1",
+			"type": "headers",
+			"property": "access-control-allow-origin",
+			"actual_value": "close",
+			"comparison_type": "=",
+			"expected_value": "*",
+			"pass": false
+	},
   {
-    "name": "first_get_test",
+    "name": "example-test-name3",
     "method": "GET",
-    "url": "https://trellific.corkboard.dev/api/boards",
-    "region": "us-east-1",
-    "type": "response_time_ms",
-    "property": null,
-    "actual_value": "237",
-    "comparison_type": "<=",
-    "expected_value": "500",
-    "pass": true
-  },
-  {
-    "name": "first_get_test",
-    "method": "GET",
-    "url": "https://trellific.corkboard.dev/api/boards",
+    "url": "https://example-website.com",
     "region": "ca-central-1",
-    "type": "response_time_ms",
-    "property": null,
-    "actual_value": "423",
-    "comparison_type": "<=",
-    "expected_value": "500",
-    "pass": false
-  },
-  {
-    "name": "first_get_test",
-    "method": "GET",
-    "url": "https://trellific.corkboard.dev/api/boards",
-    "region": "ca-central-1",
-    "type": "status_code",
+    "type": "statusCode",
     "property": null,
     "actual_value": "200",
     "comparison_type": "=",
@@ -225,7 +223,7 @@ no payload
 
 ### 1.4.2. Successful Response
 
-The tests runs are returned in JSON format with a 200 response status code.
+The tests runs are returned in JSON format with a 200 OK response status code.
 
 #### 1.4.2.1. Example Response
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,9 +4,9 @@
   - [1.1. POST /api/tests](#14-post-apitests)
   - [1.2. GET /api/tests](#99-get-apitests)
   - [1.3. GET /api/tests/:id](#158-get-apitest)
-	- [1.4. GET /api/sideload](#201-get-sideload)
-	- [1.5. POST /api/tests/:id/run](#298-post-apitestrun)
-	- [1.6. GET /api/tests/:id/run](#304-get-apitestruns)
+  - [1.4. GET /api/sideload](#201-get-sideload)
+  - [1.5. POST /api/tests/:id/run](#298-post-apitestrun)
+  - [1.6. GET /api/tests/:id/run](#304-get-apitestruns)
 
 
 ## 1.1. POST /api/tests
@@ -171,28 +171,28 @@ The tests runs are returned in JSON format with a 200 response status code.
 
 ```json
 [
-	{
-			"name": "example-test-name1",
-			"url": "https://example-website.com",
-			"region": "us-west-1",
-			"type": "statusCode",
-			"property": null,
-			"actual_value": "200",
-			"comparison_type": "=",
-			"expected_value": "200",
-			"pass": false
-	}
-	{
-			"name": "example-test-name2",
-			"url": "https://example-website.com",
-			"region": "us-west-1",
-			"type": "headers",
-			"property": "access-control-allow-origin",
-			"actual_value": "close",
-			"comparison_type": "=",
-			"expected_value": "*",
-			"pass": false
-	},
+  {
+      "name": "example-test-name1",
+      "url": "https://example-website.com",
+      "region": "us-west-1",
+      "type": "statusCode",
+      "property": null,
+      "actual_value": "200",
+      "comparison_type": "=",
+      "expected_value": "200",
+      "pass": false
+  }
+  {
+      "name": "example-test-name2",
+      "url": "https://example-website.com",
+      "region": "us-west-1",
+      "type": "headers",
+      "property": "access-control-allow-origin",
+      "actual_value": "close",
+      "comparison_type": "=",
+      "expected_value": "*",
+      "pass": false
+  },
   {
     "name": "example-test-name3",
     "method": "GET",

--- a/routes/api.js
+++ b/routes/api.js
@@ -9,7 +9,7 @@ router.post('/tests', validateTest, testsController.createTest);
 router.get('/tests', testsController.getScheduledTests);
 router.get('/tests/:id', testsController.getTest);
 router.get('/sideload', sideloadController.getSideload);
-router.get('/tests/run/:id', testsController.runNow);
+router.post('/tests/:id/run', testsController.runNow);
 router.get('/tests/:id/runs', testsController.getTestRuns);
 
 module.exports = router;


### PR DESCRIPTION
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>

This PR: 
- updates documentation:
  - adds new endpoint `GET /:id/runs` 
  - changes endpoint `GET /run/:id` to `POST /:id/run` 
  - updates sideload endpoint example response to return names in camel case instead of snake case 
- updates endpoint in `routes/api` from  `GET /run/:id` to `POST /:id/run` 
