### PR TITLE
update column names for consistency

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -2,14 +2,18 @@ CREATE TABLE assertion_types (
   id serial PRIMARY KEY,
   name text NOT NULL UNIQUE,
   display_name text NOT NULL UNIQUE,
-  supported BOOLEAN
+  supported BOOLEAN,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP
 );
 
 CREATE TABLE http_methods (
   id serial PRIMARY KEY,
   name text NOT NULL UNIQUE,
   display_name text NOT NULL UNIQUE,
-  supported BOOLEAN
+  supported BOOLEAN,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP
 );
 
 CREATE TABLE comparison_types (
@@ -17,7 +21,9 @@ CREATE TABLE comparison_types (
   name text NOT NULL UNIQUE,
   display_name text NOT NULL UNIQUE,
   symbol text UNIQUE,
-  supported BOOLEAN
+  supported BOOLEAN,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP
 ); 
 
 CREATE TABLE regions (
@@ -26,7 +32,9 @@ CREATE TABLE regions (
   display_name text NOT NULL UNIQUE,
   aws_name text NOT NULL UNIQUE,
   flag_url text NOT NULL,
-  supported BOOLEAN
+  supported BOOLEAN,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP
 );
 
 CREATE TABLE tests (
@@ -51,6 +59,8 @@ CREATE TABLE notification_settings (
   id serial PRIMARY KEY,
   alerts_on_recovery BOOLEAN NOT NULL,
   alerts_on_failure BOOLEAN NOT NULL
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP
 ); 
 
 CREATE TABLE alerts (
@@ -60,7 +70,9 @@ CREATE TABLE alerts (
   notification_settings_id INT
     NOT NULL
     REFERENCES notification_settings (id)
-    ON DELETE CASCADE
+    ON DELETE CASCADE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP
 );
 
 CREATE TABLE tests_alerts (
@@ -72,7 +84,9 @@ CREATE TABLE tests_alerts (
   alerts_id INT
     NOT NULL
     REFERENCES alerts (id)
-    ON DELETE CASCADE
+    ON DELETE CASCADE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP
 );
 
 CREATE TABLE test_runs (
@@ -83,15 +97,17 @@ CREATE TABLE test_runs (
     ON DELETE CASCADE,
   started_at TIMESTAMP NOT NULL,
   completed_at TIMESTAMP,
-  pass BOOLEAN,
+  success BOOLEAN,
   region_id INT
     NOT NULL
     REFERENCES regions (id)
     ON DELETE CASCADE,
-  response_status TEXT,
-  response_time TEXT,
+  response_status TEXT NOT NULL,
+  response_time TEXT NOT NULL,
   response_body JSONB,
-  response_headers JSONB
+  response_headers JSONB NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP
 ); 
 
 CREATE TABLE tests_regions (
@@ -104,6 +120,8 @@ CREATE TABLE tests_regions (
     NOT NULL
     REFERENCES regions (id)
     ON DELETE CASCADE
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP
 ); 
 
 CREATE TABLE assertions (
@@ -118,7 +136,9 @@ CREATE TABLE assertions (
     NOT NULL
     REFERENCES comparison_types (id)
     ON DELETE CASCADE,
-  expected_value text
+  expected_value text,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP
 ); 
 
 CREATE TABLE assertion_results (
@@ -132,14 +152,7 @@ CREATE TABLE assertion_results (
     REFERENCES assertions (id)
     ON DELETE CASCADE,
   actual_value text,
-  pass BOOLEAN NOT NULL
-); 
-
--- CREATE TABLE slack_alerts (
---   id serial PRIMARY KEY,
---   webhook text NOT NULL,
---   notification_settings_id INT
---     NOT NULL
---     REFERENCES notification_settings (id)
---     ON DELETE CASCADE
--- );
+  success BOOLEAN NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP
+);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -58,7 +58,7 @@ CREATE TABLE tests (
 CREATE TABLE notification_settings (
   id serial PRIMARY KEY,
   alerts_on_recovery BOOLEAN NOT NULL,
-  alerts_on_failure BOOLEAN NOT NULL
+  alerts_on_failure BOOLEAN NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMP
 ); 
@@ -119,7 +119,7 @@ CREATE TABLE tests_regions (
   region_id INT
     NOT NULL
     REFERENCES regions (id)
-    ON DELETE CASCADE
+    ON DELETE CASCADE,
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMP
 ); 
@@ -137,8 +137,8 @@ CREATE TABLE assertions (
     REFERENCES comparison_types (id)
     ON DELETE CASCADE,
   expected_value text,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP
 ); 
 
 CREATE TABLE assertion_results (

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -102,10 +102,10 @@ CREATE TABLE test_runs (
     NOT NULL
     REFERENCES regions (id)
     ON DELETE CASCADE,
-  response_status TEXT NOT NULL,
-  response_time TEXT NOT NULL,
+  response_status TEXT,
+  response_time TEXT,
   response_body JSONB,
-  response_headers JSONB NOT NULL,
+  response_headers JSONB,
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMP
 ); 


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR:
* Adds `created_at` and `updated_at` columns to all tables
* Renames `pass` columns to `success` for consistency
* Makes select columns in test_runs not nullable