### PR TITLE
add new get tests endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -80,7 +80,7 @@ The payload received from the client (refer to 1.1.1) is forwarded to EventBridg
 
 ## 1.2. GET /api/tests
 
-Get all scheduled test
+Get all tests and results from last three runs
 
 ### 1.2.1. Expected Payload
 
@@ -88,7 +88,7 @@ no payload
 
 ### 1.2.2. Successful Response
 
-The scheduled tests are returned in JSON format with a 200 response status code.
+The tests are returned in JSON format with a 200 response status code.
 
 #### 1.2.2.1. Example Response
 
@@ -96,40 +96,95 @@ The scheduled tests are returned in JSON format with a 200 response status code.
 {
     "tests": [
         {
+            "id": 1,
+            "name": "New-tesst-deployed",
+            "minutesBetweenRuns": 1,
+            "runs": [
+                {
+                    "success": false,
+                    "createdAt": "2022-07-27T05:23:57.982Z"
+                },
+                {
+                    "success": null,
+                    "createdAt": "2022-07-27T05:22:14.703Z"
+                },
+                {
+                    "success": null,
+                    "createdAt": "2022-07-27T05:21:16.181Z"
+                }
+            ]
+        },
+        {
+            "id": 2,
+            "name": "New-test-deployed-2",
+            "minutesBetweenRuns": 1,
+            "runs": [
+                {
+                    "success": true,
+                    "createdAt": "2022-07-27T09:05:14.687Z"
+                },
+                {
+                    "success": true,
+                    "createdAt": "2022-07-27T09:05:14.128Z"
+                },
+                {
+                    "success": true,
+                    "createdAt": "2022-07-27T09:05:14.108Z"
+                }
+            ]
+        },
+        {
+            "id": 3,
+            "name": "0726-t1",
+            "minutesBetweenRuns": 1,
+            "runs": [
+                {
+                    "success": true,
+                    "createdAt": "2022-07-27T06:31:57.264Z"
+                },
+                {
+                    "success": true,
+                    "createdAt": "2022-07-27T06:26:15.211Z"
+                },
+                {
+                    "success": true,
+                    "createdAt": "2022-07-27T06:25:15.331Z"
+                }
+            ]
+        },
+        {
             "id": 100000,
             "name": "first-get-test",
-            "run_frequency_mins": 5,
-            "method_id": 1,
-            "url": "https://trellific.corkboard.dev/api/boards",
-            "headers": {},
-            "body": {},
-            "query_params": null,
-            "teardown": null,
-            "status": "enabled",
-            "eb_rule_arn": "arn:imfake",
-            "created_at": "2022-07-27T03:07:31.632Z",
-            "updated_at": null
+            "minutesBetweenRuns": 5,
+            "runs": [
+                {
+                    "success": true,
+                    "createdAt": "2022-07-27T04:07:31.632Z"
+                },
+                {
+                    "success": true,
+                    "createdAt": "2022-07-27T04:07:31.632Z"
+                },
+                {
+                    "success": true,
+                    "createdAt": "2022-07-27T04:07:31.632Z"
+                }
+            ]
         },
         {
             "id": 100001,
             "name": "first-post-test",
-            "run_frequency_mins": 5,
-            "method_id": 2,
-            "url": "https://trellific.corkboard.dev/api/boards",
-            "headers": {
-                "Content-Type": "application/json"
-            },
-            "body": {
-                "board": {
-                    "title": "post-test-board"
+            "minutesBetweenRuns": 5,
+            "runs": [
+                {
+                    "success": null,
+                    "createdAt": "2022-07-27T04:07:31.632Z"
+                },
+                {
+                    "success": true,
+                    "createdAt": "2022-07-27T04:07:31.632Z"
                 }
-            },
-            "query_params": null,
-            "teardown": null,
-            "status": "enabled",
-            "eb_rule_arn": "arn:imfake",
-            "created_at": "2022-07-27T03:07:31.632Z",
-            "updated_at": null
+            ]
         }
     ]
 }

--- a/entities/Test.js
+++ b/entities/Test.js
@@ -1,0 +1,14 @@
+class Test {
+  constructor({ id, name, minutesBetweenRuns }) {
+    this.id = id;
+    this.name = name;
+    this.minutesBetweenRuns = minutesBetweenRuns;
+    this.runs = [];
+  }
+
+  addRun(run) {
+    this.runs.push(run);
+  }
+}
+
+module.exports = Test;

--- a/entities/TestRun.js
+++ b/entities/TestRun.js
@@ -1,0 +1,12 @@
+class TestRun {
+  constructor({
+    id, testId, success, createdAt,
+  }) {
+    this.id = id;
+    this.testId = testId;
+    this.success = success;
+    this.createdAt = createdAt;
+  }
+}
+
+module.exports = TestRun;

--- a/entities/Tests.js
+++ b/entities/Tests.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-underscore-dangle */
+class Tests {
+  constructor() {
+    this._tests = [];
+  }
+
+  containsTest(testId) {
+    return this._tests.filter((test) => test.id === testId).length > 0;
+  }
+
+  addTest(test) {
+    if (!this.containsTest(test.id)) {
+      this._tests.push(test);
+    }
+  }
+
+  getTest(testId) {
+    return this._tests.filter((test) => test.id === testId)[0];
+  }
+
+  get tests() {
+    return this._tests;
+  }
+}
+
+module.exports = Tests;

--- a/lib/db/queries/getAllTests.js
+++ b/lib/db/queries/getAllTests.js
@@ -1,0 +1,31 @@
+const { dbQuery } = require('../conn');
+
+async function getAllTests() {
+  const query = `
+  WITH ranked_test_runs AS (
+    SELECT 
+        success,
+        test_id,
+        id,
+        created_at,
+        RANK() OVER (PARTITION BY test_id ORDER BY created_at DESC) AS rank
+    FROM test_runs
+  )
+  SELECT 
+      t.id AS test_id,
+      t.name,
+      t.run_frequency_mins,
+      t.id AS run_id, 
+      rtr.success,
+      rtr.rank,
+      rtr.created_at
+  FROM tests t 
+  JOIN ranked_test_runs rtr ON rtr.test_id = t.id AND rtr.rank <= 3
+  ORDER BY test_id, rank ASC
+  `;
+
+  const result = await dbQuery(query);
+  return result.rows;
+}
+
+module.exports = getAllTests;

--- a/mappers/model-to-entity/test.js
+++ b/mappers/model-to-entity/test.js
@@ -1,0 +1,27 @@
+const Test = require('../../entities/Test');
+const { entityToJsonTestRun } = require('./testRun');
+
+const modelToEntityTest = (modelTestRow) => new Test({
+  id: modelTestRow.test_id,
+  name: modelTestRow.name,
+  minutesBetweenRuns: modelTestRow.run_frequency_mins,
+});
+
+const entityToJsonTest = (entityTest) => ({
+  id: entityTest.id,
+  name: entityTest.name,
+  minutesBetweenRuns: entityTest.minutesBetweenRuns,
+  runs: entityTest.runs.map((run) => entityToJsonTestRun(run)),
+});
+
+const entityToJsonTests = (entityTests) => {
+  const r = entityTests.tests.map((test) => entityToJsonTest(test));
+  return {
+    tests: r,
+  };
+};
+
+module.exports = {
+  modelToEntityTest,
+  entityToJsonTests,
+};

--- a/mappers/model-to-entity/testRun.js
+++ b/mappers/model-to-entity/testRun.js
@@ -1,0 +1,18 @@
+const TestRun = require('../../entities/TestRun');
+
+const modelToEntityTestRun = (testRunData) => new TestRun({
+  id: testRunData.run_id,
+  testId: testRunData.test_id,
+  success: testRunData.success,
+  createdAt: testRunData.created_at,
+});
+
+const entityToJsonTestRun = (testRunEntity) => ({
+  success: testRunEntity.success,
+  createdAt: testRunEntity.createdAt,
+});
+
+module.exports = {
+  modelToEntityTestRun,
+  entityToJsonTestRun,
+};

--- a/routes/api.js
+++ b/routes/api.js
@@ -6,7 +6,8 @@ const { validateTest } = require('../validators/test');
 const router = express.Router();
 
 router.post('/tests', validateTest, testsController.createTest);
-router.get('/tests', testsController.getScheduledTests);
+// router.get('/tests', testsController.getScheduledTests);
+router.get('/tests', testsController.getTests);
 router.get('/tests/:id', testsController.getTest);
 router.get('/sideload', sideloadController.getSideload);
 router.post('/tests/:id/run', testsController.runNow);


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR: 
* Creates a new directory for individual query files to avoid the growth of the `queries.js` file
* Adds `Test`, `Tests` and `TestRun` entities for code organization 
* Adds mappers, which are responsible for converting data between three forms: entity, model (i.e. db rows), json 
* Adds a route that return data for all tests, including the results of the three most recent runs. This will support the `/tests` view

# Validation 

Made the following request locally: `GET http://localhost:5001/api/tests`
## Response (status 200)
```json
{
    "tests": [
        {
            "id": 1,
            "name": "New-tesst-deployed",
            "minutesBetweenRuns": 1,
            "runs": [
                {
                    "success": false,
                    "createdAt": "2022-07-27T05:23:57.982Z"
                },
                {
                    "success": null,
                    "createdAt": "2022-07-27T05:22:14.703Z"
                },
                {
                    "success": null,
                    "createdAt": "2022-07-27T05:21:16.181Z"
                }
            ]
        },
        {
            "id": 2,
            "name": "New-test-deployed-2",
            "minutesBetweenRuns": 1,
            "runs": [
                {
                    "success": true,
                    "createdAt": "2022-07-27T09:05:14.687Z"
                },
                {
                    "success": true,
                    "createdAt": "2022-07-27T09:05:14.128Z"
                },
                {
                    "success": true,
                    "createdAt": "2022-07-27T09:05:14.108Z"
                }
            ]
        },
        {
            "id": 3,
            "name": "0726-t1",
            "minutesBetweenRuns": 1,
            "runs": [
                {
                    "success": true,
                    "createdAt": "2022-07-27T06:31:57.264Z"
                },
                {
                    "success": true,
                    "createdAt": "2022-07-27T06:26:15.211Z"
                },
                {
                    "success": true,
                    "createdAt": "2022-07-27T06:25:15.331Z"
                }
            ]
        },
        {
            "id": 100000,
            "name": "first-get-test",
            "minutesBetweenRuns": 5,
            "runs": [
                {
                    "success": true,
                    "createdAt": "2022-07-27T04:07:31.632Z"
                },
                {
                    "success": true,
                    "createdAt": "2022-07-27T04:07:31.632Z"
                },
                {
                    "success": true,
                    "createdAt": "2022-07-27T04:07:31.632Z"
                }
            ]
        },
        {
            "id": 100001,
            "name": "first-post-test",
            "minutesBetweenRuns": 5,
            "runs": [
                {
                    "success": null,
                    "createdAt": "2022-07-27T04:07:31.632Z"
                },
                {
                    "success": true,
                    "createdAt": "2022-07-27T04:07:31.632Z"
                }
            ]
        }
    ]
}
```