### PR TITLE
add validation for title pattern

### DIFF
--- a/validators/test.js
+++ b/validators/test.js
@@ -2,6 +2,7 @@ const { check } = require('express-validator');
 
 const MINIMUM_TITLE_LENGTH = 5;
 const MAXIMUM_TITLE_LENGTH = 128;
+const TITLE_REGEX = /^[.\-_A-Za-z0-9]+$/;
 const TEST_TYPES = ['api'];
 // TODO: pull from database?
 const HTTP_METHODS = ['get', 'post', 'put', 'delete'];
@@ -18,7 +19,9 @@ exports.validateTest = [
     .isLength({ min: MINIMUM_TITLE_LENGTH })
     .withMessage(`must be at least ${MINIMUM_TITLE_LENGTH} characters long`)
     .isLength({ max: 128 })
-    .withMessage(`must be at most ${MAXIMUM_TITLE_LENGTH} characters long`),
+    .withMessage(`must be at most ${MAXIMUM_TITLE_LENGTH} characters long`)
+    .matches(TITLE_REGEX)
+    .withMessage(`must satisfy regular expression pattern: ${TITLE_REGEX}`),
   check('test.locations')
     .isArray()
     .withMessage('must be an array'),


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>

New validation conforms with AWS rules regarding test names.

Given the following request (test name includes spaces):
![Screen Shot 2022-07-27 at 12 42 39 PM](https://user-images.githubusercontent.com/72320460/181348220-95f25d8f-0420-4994-9a75-473acb90d889.jpg)

CRUD now responds with the following:
![Screen Shot 2022-07-27 at 12 43 13 PM](https://user-images.githubusercontent.com/72320460/181348314-a726d734-87b8-452c-b0f4-7a1bbaf19f91.jpg)

Note that the expression pattern in the response JSON includes an additional backslash (JSON escape character) to preserve the REGEX escape character
