### PR TITLE
replace window functions for getAllTests query

### DIFF
--- a/lib/db/queries/getAllTests.js
+++ b/lib/db/queries/getAllTests.js
@@ -8,7 +8,7 @@ async function getAllTests() {
         test_id,
         id,
         created_at,
-        RANK() OVER (PARTITION BY test_id ORDER BY created_at DESC) AS rank
+        ROW_NUMBER() OVER (PARTITION BY test_id ORDER BY created_at DESC) AS rank
     FROM test_runs
   )
   SELECT 


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>

This PR addresses the following bug:

In the event that a given array of test runs has > 3 runs with the same `createdAt` property, the DB query `getAllTestRuns` may return more than the three most recent runs.

To fix this error we replace the PostgreSQL window function `RANK` with `ROW_NUMBER`

The main difference between the two window functions are as follows:

`ROW_NUMBER` : Returns a unique number for each row starting with 1. For rows that have duplicate values,numbers are arbitrarily assigned.

`RANK` : Assigns a unique number for each row starting with 1,except for rows that have duplicate values, in which case the same ranking is assigned and a gap appears in the sequence for each duplicate ranking.
