### PR TITLE
add ids needed by frontend to two endpoints

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -134,21 +134,21 @@ The tests are returned in JSON format with a 200 response status code.
             "createdAt": "2022-07-28T04:31:38.157Z",
             "runs": [
                 {
-                    "id": 14,
+                    "id": 847,
                     "testId": 14,
                     "success": true,
                     "createdAt": "2022-07-28T04:33:47.514Z",
                     "assertions": []
                 },
                 {
-                    "id": 14,
+                    "id": 846,
                     "testId": 14,
                     "success": false,
                     "createdAt": "2022-07-28T04:33:47.238Z",
                     "assertions": []
                 },
                 {
-                    "id": 14,
+                    "id": 845,
                     "testId": 14,
                     "success": false,
                     "createdAt": "2022-07-28T04:33:00.915Z",
@@ -163,21 +163,14 @@ The tests are returned in JSON format with a 200 response status code.
             "createdAt": "2022-07-27T04:07:31.632Z",
             "runs": [
                 {
-                    "id": 100000,
+                    "id": 840,
                     "testId": 100000,
                     "success": false,
                     "createdAt": "2022-07-28T04:20:39.445Z",
                     "assertions": []
                 },
                 {
-                    "id": 100000,
-                    "testId": 100000,
-                    "success": true,
-                    "createdAt": "2022-07-27T04:07:31.632Z",
-                    "assertions": []
-                },
-                {
-                    "id": 100000,
+                    "id": 100001,
                     "testId": 100000,
                     "success": true,
                     "createdAt": "2022-07-27T04:07:31.632Z",
@@ -199,16 +192,16 @@ The tests are returned in JSON format with a 200 response status code.
             "createdAt": "2022-07-27T04:07:31.632Z",
             "runs": [
                 {
-                    "id": 100001,
+                    "id": 100004,
                     "testId": 100001,
-                    "success": true,
+                    "success": null,
                     "createdAt": "2022-07-27T04:07:31.632Z",
                     "assertions": []
                 },
                 {
-                    "id": 100001,
+                    "id": 100003,
                     "testId": 100001,
-                    "success": null,
+                    "success": true,
                     "createdAt": "2022-07-27T04:07:31.632Z",
                     "assertions": []
                 }
@@ -533,6 +526,7 @@ no playload
             "responseHeaders": {},
             "assertions": [
                 {
+                    "id": 100000,
                     "type": "statusCode",
                     "property": null,
                     "comparison": "equalTo",
@@ -541,6 +535,7 @@ no playload
                     "success": true
                 },
                 {
+                    "id": 100001,
                     "type": "responseTimeMs",
                     "property": null,
                     "comparison": "lessThan",

--- a/lib/db/queries/getAllTests.js
+++ b/lib/db/queries/getAllTests.js
@@ -16,7 +16,7 @@ async function getAllTests() {
       t.name AS test_name,
       t.run_frequency_mins AS test_run_frequency_mins,
       t.created_at AS test_created_at,
-      t.id AS run_id,
+      rtr.id AS run_id,
       rtr.success AS run_success,
       rtr.rank run_rank,
       rtr.created_at AS run_created_at

--- a/lib/db/queries/getTestRun.js
+++ b/lib/db/queries/getTestRun.js
@@ -18,6 +18,7 @@ async function getTestRun(runId) {
     tr.response_status AS run_response_status,
     tr.response_body AS run_response_body,
     tr.response_headers AS run_response_headers,
+    a.id AS assertion_id,
     a.type AS assertion_type,
     a.property AS assertion_property,
     cp.name AS assertion_comparison,

--- a/mappers/assertion.js
+++ b/mappers/assertion.js
@@ -12,6 +12,7 @@ const modelToEntityAssertion = (modelAssertionRow) => new Assertion({
 });
 
 const entityToJsonAssertion = (assertion) => ({
+  id: assertion.id,
   type: assertion.type,
   property: assertion.property,
   comparison: assertion.comparison,

--- a/mappers/test.js
+++ b/mappers/test.js
@@ -16,6 +16,7 @@ const entityToJsonTest = (entityTest) => ({
   minutesBetweenRuns: entityTest.minutesBetweenRuns,
   method: entityTest.method,
   createdAt: entityTest.createdAt,
+  url: entityTest.url,
   runs: entityTest.runs.map((run) => entityToJsonTestRun(run)),
 });
 


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR:
* Adds assertion Ids to the `GET /api/tests/:id/runs/:id` endpoint 
* Adds the test url to the `GET /api/tests/:id/runs/:id` endpoint 
* Adds the proper run id to the `GET /api/tests` endpoint

# Validation
## Test 1
### Request
`GET http://localhost:5001/api/tests/13/runs/833`
### Response 
```json
{
    "id": 13,
    "name": "0727-t4",
    "method": "post",
    "createdAt": "2022-07-28T01:25:52.654Z",
    "runs": [
        {
            "id": 833,
            "testId": 13,
            "success": true,
            "completedAt": "2022-07-28T01:26:30.883Z",
            "regionName": "eu-north-1",
            "regionDisplayName": "Stockholm",
            "regionFlagUrl": "https://countryflagsapi.com/png/sweden",
            "responseTime": "607",
            "responseStatus": "201",
            "responseBody": {
                "_id": "62e1835397e4e03502e0c79c",
                "title": "0727-t4 board test",
                "createdAt": "2022-07-27T18:26:27.421Z",
                "updatedAt": "2022-07-27T18:26:27.421Z"
            },
            "responseHeaders": {
                "date": "Wed, 27 Jul 2022 18:26:27 GMT",
                "etag": "W/\"8d-6pBWsSkppIUQ3VfbjSMdxQVaCRY\"",
                "server": "nginx/1.18.0 (Ubuntu)",
                "connection": "close",
                "content-type": "application/json; charset=utf-8",
                "x-powered-by": "Express",
                "content-length": "141",
                "request-duration": 607,
                "access-control-allow-origin": "*",
                "access-control-allow-headers": "Origin, X-Requested-With, Content-Type, Accept"
            },
            "assertions": [
                {
                    "id": 33,
                    "type": "responseTime",
                    "property": null,
                    "comparison": "lessThan",
                    "expectedValue": "700",
                    "actualValue": "607",
                    "success": true
                },
                {
                    "id": 34,
                    "type": "statusCode",
                    "property": null,
                    "comparison": "equalTo",
                    "expectedValue": "201",
                    "actualValue": "201",
                    "success": true
                }
            ]
        }
    ]
}
```

## Test 2
### Request
`GET http://localhost:5001/api/tests`
### Response 
```json
{
    "tests": [
        {
            "id": 3,
            "name": "0726-t1",
            "minutesBetweenRuns": 1,
            "createdAt": "2022-07-27T06:22:09.996Z",
            "runs": [
                {
                    "id": 317,
                    "testId": 3,
                    "success": true,
                    "createdAt": "2022-07-27T06:31:57.264Z",
                    "assertions": []
                },
                {
                    "id": 299,
                    "testId": 3,
                    "success": true,
                    "createdAt": "2022-07-27T06:26:15.211Z",
                    "assertions": []
                },
                {
                    "id": 295,
                    "testId": 3,
                    "success": true,
                    "createdAt": "2022-07-27T06:25:15.331Z",
                    "assertions": []
                }
            ]
        },
        {
            "id": 12,
            "name": "tim-E2E-jul-27",
            "minutesBetweenRuns": 3,
            "createdAt": "2022-07-28T00:53:22.344Z",
            "runs": [
                {
                    "id": 831,
                    "testId": 12,
                    "success": true,
                    "createdAt": "2022-07-28T01:02:50.854Z",
                    "assertions": []
                },
                {
                    "id": 830,
                    "testId": 12,
                    "success": false,
                    "createdAt": "2022-07-28T01:02:40.315Z",
                    "assertions": []
                },
                {
                    "id": 829,
                    "testId": 12,
                    "success": true,
                    "createdAt": "2022-07-28T00:59:50.931Z",
                    "assertions": []
                }
            ]
        },
        {
            "id": 13,
            "name": "0727-t4",
            "minutesBetweenRuns": 1,
            "createdAt": "2022-07-28T01:25:52.654Z",
            "runs": [
                {
                    "id": 839,
                    "testId": 13,
                    "success": true,
                    "createdAt": "2022-07-28T01:29:30.007Z",
                    "assertions": []
                },
                {
                    "id": 838,
                    "testId": 13,
                    "success": true,
                    "createdAt": "2022-07-28T01:29:29.085Z",
                    "assertions": []
                },
                {
                    "id": 837,
                    "testId": 13,
                    "success": true,
                    "createdAt": "2022-07-28T01:28:29.945Z",
                    "assertions": []
                }
            ]
        },
        {
            "id": 14,
            "name": "New-UI-test",
            "minutesBetweenRuns": 1,
            "createdAt": "2022-07-28T04:31:38.157Z",
            "runs": [
                {
                    "id": 847,
                    "testId": 14,
                    "success": true,
                    "createdAt": "2022-07-28T04:33:47.514Z",
                    "assertions": []
                },
                {
                    "id": 846,
                    "testId": 14,
                    "success": false,
                    "createdAt": "2022-07-28T04:33:47.238Z",
                    "assertions": []
                },
                {
                    "id": 845,
                    "testId": 14,
                    "success": false,
                    "createdAt": "2022-07-28T04:33:00.915Z",
                    "assertions": []
                }
            ]
        },
        {
            "id": 100000,
            "name": "first-get-test",
            "minutesBetweenRuns": 5,
            "createdAt": "2022-07-27T04:07:31.632Z",
            "runs": [
                {
                    "id": 840,
                    "testId": 100000,
                    "success": false,
                    "createdAt": "2022-07-28T04:20:39.445Z",
                    "assertions": []
                },
                {
                    "id": 100001,
                    "testId": 100000,
                    "success": true,
                    "createdAt": "2022-07-27T04:07:31.632Z",
                    "assertions": []
                },
                {
                    "id": 100000,
                    "testId": 100000,
                    "success": true,
                    "createdAt": "2022-07-27T04:07:31.632Z",
                    "assertions": []
                }
            ]
        },
        {
            "id": 100001,
            "name": "first-post-test",
            "minutesBetweenRuns": 5,
            "createdAt": "2022-07-27T04:07:31.632Z",
            "runs": [
                {
                    "id": 100004,
                    "testId": 100001,
                    "success": null,
                    "createdAt": "2022-07-27T04:07:31.632Z",
                    "assertions": []
                },
                {
                    "id": 100003,
                    "testId": 100001,
                    "success": true,
                    "createdAt": "2022-07-27T04:07:31.632Z",
                    "assertions": []
                }
            ]
        }
    ]
}
```