### PR TITLE
add missing url property to get test run endpoint response

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -599,6 +599,7 @@ no playload
     "name": "first-get-test",
     "method": "get",
     "createdAt": "2022-07-27T04:07:31.632Z",
+    "url": "https://trellific.corkboard.dev/api/boards",
     "runs": [
         {
             "id": 100000,

--- a/entities/Test.js
+++ b/entities/Test.js
@@ -1,12 +1,13 @@
 /* eslint-disable no-underscore-dangle */
 class Test {
   constructor({
-    id, name, minutesBetweenRuns, method, createdAt,
+    id, name, minutesBetweenRuns, method, url, createdAt,
   }) {
     this._id = id;
     this._name = name;
     this._minutesBetweenRuns = minutesBetweenRuns;
     this._method = method;
+    this._url = url;
     this._createdAt = createdAt;
     this._runs = [];
   }
@@ -30,6 +31,8 @@ class Test {
   get minutesBetweenRuns() { return this._minutesBetweenRuns; }
 
   get method() { return this._method; }
+
+  get url() { return this._url; }
 
   get createdAt() { return this._createdAt; }
 


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR:
* Corrects an oversight from an earlier PR and **actually** adds a url property to the `GET /api/tests/:id/runs/:id` response

# Validation 
### Request
`GET http://localhost:5001/api/tests/11/runs/833`

### Response 
```json
{
    "id": 13,
    "name": "0727-t4",
    "method": "post",
    "createdAt": "2022-07-28T01:25:52.654Z",
    "url": "https://trellific.corkboard.dev/api/boards",
    "runs": [
        {
            "id": 833,
            "testId": 13,
            "success": true,
            "completedAt": "2022-07-28T01:26:30.883Z",
            "regionName": "eu-north-1",
            "regionDisplayName": "Stockholm",
            "regionFlagUrl": "https://countryflagsapi.com/png/sweden",
            "responseTime": "607",
            "responseStatus": "201",
            "responseBody": {
                "_id": "62e1835397e4e03502e0c79c",
                "title": "0727-t4 board test",
                "createdAt": "2022-07-27T18:26:27.421Z",
                "updatedAt": "2022-07-27T18:26:27.421Z"
            },
            "responseHeaders": {
                "date": "Wed, 27 Jul 2022 18:26:27 GMT",
                "etag": "W/\"8d-6pBWsSkppIUQ3VfbjSMdxQVaCRY\"",
                "server": "nginx/1.18.0 (Ubuntu)",
                "connection": "close",
                "content-type": "application/json; charset=utf-8",
                "x-powered-by": "Express",
                "content-length": "141",
                "request-duration": 607,
                "access-control-allow-origin": "*",
                "access-control-allow-headers": "Origin, X-Requested-With, Content-Type, Accept"
            },
            "assertions": [
                {
                    "id": 33,
                    "type": "responseTime",
                    "property": null,
                    "comparison": "lessThan",
                    "expectedValue": "700",
                    "actualValue": "607",
                    "success": true
                },
                {
                    "id": 34,
                    "type": "statusCode",
                    "property": null,
                    "comparison": "equalTo",
                    "expectedValue": "201",
                    "actualValue": "201",
                    "success": true
                }
            ]
        }
    ]
}
```