### PR TITLE
Implement edit test endpoint

### DIFF
--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -152,6 +152,20 @@ const getTestRun = async (req, res) => {
   }
 };
 
+const editTest = async (req, res) => {
+  // const errors = validationResult(req);
+  // if (errors.isEmpty()) {
+  //   try {
+  //     await createEventBridgeRule(req.body);
+  //     res.status(201).send(`Test ${req.body.test.title} created`);
+  //   } catch (err) {
+  //     console.log('Error: ', err);
+  //   }
+  // } else {
+  //   res.status(400).json({ errors: errors.array() });
+  // }
+};
+
 exports.runNow = runNow;
 exports.createTest = createTest;
 exports.getScheduledTests = getScheduledTests;
@@ -159,3 +173,4 @@ exports.getTest = getTest;
 exports.getTests = getTests;
 exports.getTestRuns = getTestRuns;
 exports.getTestRun = getTestRun;
+exports.editTest = editTest;

--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -45,12 +45,14 @@ const createEventBridgeRule = async (reqBody) => {
 };
 
 const editEventBridgeRule = async (reqBody) => {
-  const { test } = reqBody;
   let targetResponse;
 
   try {
     // EB: edit rule name and or minutesBetweenRuns
     // LAMBDA: edit all other test properties
+
+    const ebRuleArn = await DB.getEbRuleArn(reqBody);
+    console.log('EB RULE ARN: ', ebRuleArn);
   } catch (err) {
     console.log('Error: ', err);
     return err;
@@ -168,8 +170,9 @@ const getTestRun = async (req, res) => {
 const editTest = async (req, res) => {
   const errors = validationResult(req);
   if (errors.isEmpty()) {
+    const testId = req.params.id;
     try {
-      await editEventBridgeRule(req.body);
+      await editEventBridgeRule(testId, req.body);
       res.status(204).send(`Test ${req.body.test.title} updated`);
     } catch (err) {
       console.log('Error: ', err);

--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -34,14 +34,27 @@ const createEventBridgeRule = async (reqBody) => {
 
     try {
       await DB.addNewTest(ruleName, RuleArn, test);
-    } catch (e) {
-      throw new Error('Something went wrong with the database operation. Please try again');
+    } catch (err) {
+      throw new Error('Error: ', err);
     }
   } catch (err) {
     console.log('Error: ', err);
     return err;
   }
   return { targetResponse, permissionsResponse };
+};
+
+const editEventBridgeRule = async (reqBody) => {
+  const { test } = reqBody;
+  let targetResponse;
+
+  try {
+    // EB: edit rule name and or minutesBetweenRuns
+    // LAMBDA: edit all other test properties
+  } catch (err) {
+    console.log('Error: ', err);
+    return err;
+  }
 };
 
 const createTest = async (req, res) => {
@@ -156,7 +169,7 @@ const editTest = async (req, res) => {
   const errors = validationResult(req);
   if (errors.isEmpty()) {
     try {
-      // await createEventBridgeRule(req.body);
+      await editEventBridgeRule(req.body);
       res.status(204).send(`Test ${req.body.test.title} updated`);
     } catch (err) {
       console.log('Error: ', err);

--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -153,17 +153,17 @@ const getTestRun = async (req, res) => {
 };
 
 const editTest = async (req, res) => {
-  // const errors = validationResult(req);
-  // if (errors.isEmpty()) {
-  //   try {
-  //     await createEventBridgeRule(req.body);
-  //     res.status(201).send(`Test ${req.body.test.title} created`);
-  //   } catch (err) {
-  //     console.log('Error: ', err);
-  //   }
-  // } else {
-  //   res.status(400).json({ errors: errors.array() });
-  // }
+  const errors = validationResult(req);
+  if (errors.isEmpty()) {
+    try {
+      // await createEventBridgeRule(req.body);
+      res.status(204).send(`Test ${req.body.test.title} updated`);
+    } catch (err) {
+      console.log('Error: ', err);
+    }
+  } else {
+    res.status(400).json({ errors: errors.array() });
+  }
 };
 
 exports.runNow = runNow;

--- a/lib/aws/eventBridgeActions.js
+++ b/lib/aws/eventBridgeActions.js
@@ -2,8 +2,7 @@ const { PutRuleCommand, PutTargetsCommand } = require('@aws-sdk/client-eventbrid
 const { ebClient } = require('./eventBridgeClient');
 const { lambdaClient, AddPermissionCommand } = require('./lambdaClient');
 
-const createRule = async ({ name, minutesBetweenRuns }) => {
-  // test
+const createOrEditRule = async ({ name, minutesBetweenRuns }) => {
   const params = {
     Name: name,
     ScheduleExpression: String(minutesBetweenRuns) === '1' ? 'rate(1 minute)' : `rate(${minutesBetweenRuns} minutes)`,
@@ -67,7 +66,7 @@ const addTargetLambda = async ({
 };
 
 module.exports = {
-  createRule,
+  createOrEditRule,
   addTargetLambda,
   addLambdaPermissions,
 };

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -289,9 +289,20 @@ async function getTestsRuns(id) {
   return json;
 }
 
+async function getEbRuleArn(testId) {
+  const query = `
+    SELECT eb_rule_arn 
+    FROM tests 
+    WHERE id = $1
+  `;
+  const result = await dbQuery(query, testId);
+  return result.rows[0].eb_rule_arn;
+}
+
 module.exports.addNewTest = addNewTest;
 module.exports.getTests = getTests;
 module.exports.getTest = getTest;
 module.exports.getSideload = getSideload;
 module.exports.getTestBody = getTestBody;
 module.exports.getTestsRuns = getTestsRuns;
+module.exports.getEbRuleArn = getEbRuleArn;

--- a/routes/api.js
+++ b/routes/api.js
@@ -13,5 +13,6 @@ router.get('/sideload', sideloadController.getSideload);
 router.get('/tests/:testId/runs/:runId', testsController.getTestRun);
 router.post('/tests/:id/run', testsController.runNow);
 router.get('/tests/:id/runs', testsController.getTestRuns);
+router.put('/tests/:id', testsController);
 
 module.exports = router;

--- a/routes/api.js
+++ b/routes/api.js
@@ -13,6 +13,6 @@ router.get('/sideload', sideloadController.getSideload);
 router.get('/tests/:testId/runs/:runId', testsController.getTestRun);
 router.post('/tests/:id/run', testsController.runNow);
 router.get('/tests/:id/runs', testsController.getTestRuns);
-router.put('/tests/:id', testsController);
+router.put('/tests/:id', testsController.editTest);
 
 module.exports = router;


### PR DESCRIPTION
This PR:

- adds a new endpoint `PUT /api/tests/:id`
- adds functionality to edit the scheduled interval for an existing test
- renames the `createRule` function to `createOrEditRule` in the EB actions file.

Edit schedule functionality is performed through the `PutRuleCommand` of the AWS-SDK in the same manner as creating a new test. If `params.name` passed to `PutRuleCommand` matches an existing rule, the remaining params will overwrite the existing rule params (`ScheduleExpression` and `State`). If `params.name` is unique (eg the user edited the name of the test on the front end), EB will Create a brand new rule in addition to the existing rule. 

### **Implication for Front-End: Do not allow user to edit test name**

ToDo: 
-implement functionality to edit remaining test properties (via the lambda SDK)
-save edited data to DB

## E2E Testing validation

![Screen Shot 2022-07-28 at 11 28 32 AM](https://user-images.githubusercontent.com/72320460/181602829-bc8f3096-7c34-405b-994b-68c3031e81ee.jpg)
![Screen Shot 2022-07-28 at 11 44 04 AM](https://user-images.githubusercontent.com/72320460/181603102-bbc6034d-9533-4afd-b67d-c14f8918a72b.jpg)
![Screen Shot 2022-07-28 at 11 27 11 AM](https://user-images.githubusercontent.com/72320460/181603167-91711b87-9fa5-4828-b246-c63f6f84cd8a.jpg)

