### PR TITLE
updating run now endpoint

### DIFF
--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -199,7 +199,7 @@ async function getTestBody(testId) {
    a.type,
    a.property,
    ct.name as comparison,
-   a.expected_value
+   a.expected_value target
   FROM assertions a
     JOIN comparison_types ct
     ON a.comparison_type_id = ct.id

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -78,13 +78,16 @@ async function addNewTestAlert(testId, alertChannel) {
 }
 
 async function addNewTestAlerts(testId, alertChannels) {
-  try {
-    // eslint-disable-next-line max-len
-    const result = await Promise.all(alertChannels.map((channel) => addNewTestAlert(testId, channel)));
-    console.log('Add New Test Alerts Result: ', result);
-  } catch (e) {
-    console.error(e);
-  }
+	///if no alerts then don't attempt 
+	if (alertChannels) {
+		try {
+			// eslint-disable-next-line max-len
+			const result = await Promise.all(alertChannels.map((channel) => addNewTestAlert(testId, channel)));
+			console.log('Add New Test Alerts Result: ', result);
+		} catch (e) {
+			console.error(e);
+		}
+	}
 }
 
 async function addNewTestAssertions(testId, assertions) {
@@ -195,8 +198,8 @@ async function getTestBody(testId) {
   SELECT 
    a.type,
    a.property,
-   a.expected_value,
-   ct.name as comparison
+   ct.name as comparion,
+   a.expected_value
   FROM assertions a
     JOIN comparison_types ct
     ON a.comparison_type_id = ct.id
@@ -205,15 +208,18 @@ async function getTestBody(testId) {
 
   const query3 = `
     SELECT 
-      DISTINCT r.name
+      DISTINCT r.aws_name
     FROM regions r
       JOIN test_runs tr ON r.id = tr.region_id
       WHERE tr.test_id = ${testId};
     `;
 
   const testCofnig = await dbQuery(query1);
+	console.log('query1');
   const assertions = await dbQuery(query2);
+	console.log('query2');
   const locations = await dbQuery(query3);
+	console.log('query3'); 
 
   // eslint-disable-next-line object-curly-newline
   const { name, frequency, headers, body, url, method } = testCofnig.rows[0];
@@ -221,15 +227,15 @@ async function getTestBody(testId) {
   const json = {
     test: {
       title: name,
-      locations: locations.rows.map((obj) => helpers.toDash(obj.name)),
+      locations: locations.rows.map((location) => location.aws_name),
       minutesBetweenRuns: frequency,
       type: 'api',
       httpRequest: {
-        method: method.toUpperCase(),
+        method: method,
         url,
-        headers,
-        body,
-        assertions: helpers.formatAssertions(assertions.rows),
+        headers: headers || {},
+        body: body || {},
+        assertions: assertions.rows,
       },
     },
   };

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -198,7 +198,7 @@ async function getTestBody(testId) {
   SELECT 
    a.type,
    a.property,
-   ct.name as comparion,
+   ct.name as comparison,
    a.expected_value
   FROM assertions a
     JOIN comparison_types ct


### PR DESCRIPTION
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>

This PR: 

- updates `POST /tests/:id/run` endpoint to match the new JSON body:
    - updates `getTestBody` function 
    - sets `type` to `api` instead of `API`
    - sets method to be lower case 
    - `headers` and `body` are empty objects as a default
    - `assertions` is an array of objects 
    - assertion properties are `null` if there was no value

Example body that this endpoint produces: 
```json
{
    "test": {
        "title": "example-title",
        "locations": [
            "us-east-1"
        ],
        "minutesBetweenRuns": 1,
        "type": "api",
        "httpRequest": {
            "method": "get",
            "url": "https://trellific.corkboard.dev/api/boards",
            "headers": {},
            "body": {},
            "assertions": [
                {
                    "type": "responseTime",
                    "property": null,
                    "comparion": "lessThan",
                    "expected_value": "500"
                },
                {
                    "type": "statusCode",
                    "property": null,
                    "comparion": "equalTo",
                    "expected_value": "200"
                },
                {
                    "type": "header",
                    "property": "access-control-allow-origin",
                    "comparion": "equalTo",
                    "expected_value": "*"
                },
                {
                    "type": "body",
                    "property": null,
                    "comparion": "contains",
                    "expected_value": "_id"
                }
            ]
        }
    }
}
```

The assertion results: 
```javascript
[
  {
    assertionType: 'responseTime',
    targetValue: '500',
    actualValue: 360,
    comparisonType: 'lessThan',
    property: null,
    success: true
  },
  {
    assertionType: 'statusCode',
    targetValue: '200',
    actualValue: 200,
    comparisonType: 'equalTo',
    property: null,
    success: true
  },
  {
    assertionType: 'header',
    targetValue: '*',
    actualValue: '*',
    comparisonType: 'equalTo',
    property: 'access-control-allow-origin',
    success: true
  },
  {
    assertionType: 'body',
    targetValue: '_id',
    actualValue: [
      [Object], [Object], [Object],
      [Object], [Object], [Object],
      [Object], [Object], [Object],
      [Object], [Object], [Object],
      [Object], [Object], [Object],
      [Object], [Object], [Object],
      [Object]
    ],
    comparisonType: 'contains',
    property: null,
    success: true
  }
]
```