### PR TITLE
delete test endpoint added

### DIFF
--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 const { validationResult } = require('express-validator');
 const { RULE_TARGET_INFO } = require('../constants/aws/locationMappings');
-const { createRule, addTargetLambda, addLambdaPermissions } = require('../lib/aws/eventBridgeActions');
+const { createRule, addTargetLambda, addLambdaPermissions, removeRule, removePermission, removeTarget } = require('../lib/aws/eventBridgeActions');
 const DB = require('../lib/db/query');
 const queries = require('../lib/db/queries');
 const { modelToEntityTest, entityToJsonTests, entityToJsonTest } = require('../mappers/test');
@@ -152,6 +152,32 @@ const getTestRun = async (req, res) => {
   }
 };
 
+const deleteTest = async (req, res) => {
+  try {
+    const testId = req.params.id;
+    const testName = await DB.getTestName(testId);
+    try {
+      await DB.deleteTest(testId);
+    } catch (err) {
+      console.log('Error: ', err);
+      return err;
+    }
+
+    await removePermission({
+      lambdaArn: RULE_TARGET_INFO['test-route-packager'].arn,
+      statementId: `preProcessor-home_${testName}`,
+    });
+    await removeTarget({
+      testName,
+      lambdaName: RULE_TARGET_INFO['test-route-packager'].title,
+    });
+    await removeRule(testName);
+    res.status(200).send('OK');
+  } catch (err) {
+    console.log('Error: ', err);
+  }
+};
+
 exports.runNow = runNow;
 exports.createTest = createTest;
 exports.getScheduledTests = getScheduledTests;
@@ -159,3 +185,4 @@ exports.getTest = getTest;
 exports.getTests = getTests;
 exports.getTestRuns = getTestRuns;
 exports.getTestRun = getTestRun;
+exports.deleteTest = deleteTest;

--- a/lib/aws/eventBridgeActions.js
+++ b/lib/aws/eventBridgeActions.js
@@ -1,6 +1,6 @@
-const { PutRuleCommand, PutTargetsCommand } = require('@aws-sdk/client-eventbridge');
+const { PutRuleCommand, PutTargetsCommand, DeleteRuleCommand, RemoveTargetsCommand } = require('@aws-sdk/client-eventbridge');
 const { ebClient } = require('./eventBridgeClient');
-const { lambdaClient, AddPermissionCommand } = require('./lambdaClient');
+const { lambdaClient, AddPermissionCommand, RemovePermissionCommand } = require('./lambdaClient');
 
 const createRule = async ({ name, minutesBetweenRuns }) => {
   // test
@@ -66,8 +66,55 @@ const addTargetLambda = async ({
   }
 };
 
+const removeTarget = async ({ lambdaName, testName }) => {
+  const params = {
+    Ids: [lambdaName],
+    Rule: testName,
+  };
+
+  try {
+    const data = await ebClient.send(new RemoveTargetsCommand(params));
+    console.log('Success, target removed:', data);
+  } catch (err) {
+    console.log('Error', err);
+    return err;
+  }
+};
+
+const removeRule = async (ruleName) => {
+  const params = {
+    Name: ruleName,
+  };
+
+  try {
+    const data = await ebClient.send(new DeleteRuleCommand(params));
+    console.log('Success, rule delete:', data);
+  } catch (err) {
+    console.log('Error', err);
+    return err;
+  }
+};
+
+const removePermission = async ({ statementId, lambdaArn }) => {
+  const params = {
+    FunctionName: lambdaArn,
+    StatementId: statementId,
+  };
+
+  try {
+    const data = await lambdaClient.send(new RemovePermissionCommand(params));
+    console.log('Success, permission removed:', data);
+  } catch (err) {
+    console.log('Error', err);
+    return err;
+  }
+};
+
 module.exports = {
   createRule,
   addTargetLambda,
   addLambdaPermissions,
+  removeRule,
+  removePermission,
+  removeTarget,
 };

--- a/lib/aws/lambdaClient.js
+++ b/lib/aws/lambdaClient.js
@@ -1,4 +1,4 @@
-const { LambdaClient, AddPermissionCommand } = require('@aws-sdk/client-lambda');
+const { LambdaClient, AddPermissionCommand, RemovePermissionCommand } = require('@aws-sdk/client-lambda');
 const { AWS_CRED } = require('../../constants/aws/cred');
 
 const lambdaClient = new LambdaClient({ AWS_CRED });
@@ -6,4 +6,5 @@ const lambdaClient = new LambdaClient({ AWS_CRED });
 module.exports = {
   lambdaClient,
   AddPermissionCommand,
+  RemovePermissionCommand,
 };

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -178,7 +178,7 @@ async function getSideload() {
 }
 
 async function getTestBody(testId) {
-  const query1 = `
+  const configQuery = `
   SELECT 
     t.name,
     t.run_frequency_mins as frequency,
@@ -191,7 +191,7 @@ async function getTestBody(testId) {
     WHERE t.id = ${testId};
   `;
 
-  const query2 = `
+  const assertionQuery = `
   SELECT 
    a.type,
    a.property,
@@ -203,7 +203,7 @@ async function getTestBody(testId) {
     WHERE a.test_id = ${testId};
    `;
 
-  const query3 = `
+  const locationQuery = `
     SELECT 
       DISTINCT r.name
     FROM regions r
@@ -211,9 +211,9 @@ async function getTestBody(testId) {
       WHERE tr.test_id = ${testId};
     `;
 
-  const testCofnig = await dbQuery(query1);
-  const assertions = await dbQuery(query2);
-  const locations = await dbQuery(query3);
+  const testCofnig = await dbQuery(configQuery);
+  const assertions = await dbQuery(assertionQuery);
+  const locations = await dbQuery(locationQuery);
 
   // eslint-disable-next-line object-curly-newline
   const { name, frequency, headers, body, url, method } = testCofnig.rows[0];
@@ -289,9 +289,26 @@ async function getTestsRuns(id) {
   return json;
 }
 
+async function getTestName(testId) {
+  const query = `
+    SELECT name FROM tests WHERE id = ${testId}
+  `;
+  const data = await dbQuery(query);
+  return data.rows[0].name;
+}
+
+async function deleteTest(testId) {
+  const query = `DELETE FROM tests WHERE id = ${testId};`;
+
+  const data = await dbQuery(query);
+  console.log('deleted data', data);
+}
+
 module.exports.addNewTest = addNewTest;
 module.exports.getTests = getTests;
 module.exports.getTest = getTest;
 module.exports.getSideload = getSideload;
 module.exports.getTestBody = getTestBody;
 module.exports.getTestsRuns = getTestsRuns;
+module.exports.getTestName = getTestName;
+module.exports.deleteTest = deleteTest;

--- a/routes/api.js
+++ b/routes/api.js
@@ -13,5 +13,6 @@ router.get('/sideload', sideloadController.getSideload);
 router.get('/tests/:testId/runs/:runId', testsController.getTestRun);
 router.post('/tests/:id/run', testsController.runNow);
 router.get('/tests/:id/runs', testsController.getTestRuns);
+router.delete('/tests/:id', testsController.deleteTest);
 
 module.exports = router;


### PR DESCRIPTION
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>

This PR: 

- creates endpoint `DELETE '/tests/:id'`
- creates `deleteTest` function in `TestController`. The function deletes a test specified by id in the following steps:
    - makes a query to DB to get the name of the test by id
    - it deletes the test from DB and if that is successful
    - removes permission from Route Packager Lambda for that rule
    - removes the target of the rule 
    - removes the rule from the EventBridge
- renames queries

After this PR is merged it is recommended that all the tests be removed using this endpoint. It replaces three steps that needed to be done previously and assures that there are no artifacts lefts that may cause some failures. 