### PR TITLE
Completed: edit test endpoint

### DIFF
--- a/lib/aws/eventBridgeActions.js
+++ b/lib/aws/eventBridgeActions.js
@@ -2,7 +2,7 @@ const { PutRuleCommand, PutTargetsCommand } = require('@aws-sdk/client-eventbrid
 const { ebClient } = require('./eventBridgeClient');
 const { lambdaClient, AddPermissionCommand } = require('./lambdaClient');
 
-const createOrEditRule = async ({ name, minutesBetweenRuns }) => {
+const eventBridgePutRule = async ({ name, minutesBetweenRuns }) => {
   const params = {
     Name: name,
     ScheduleExpression: String(minutesBetweenRuns) === '1' ? 'rate(1 minute)' : `rate(${minutesBetweenRuns} minutes)`,
@@ -66,7 +66,7 @@ const addTargetLambda = async ({
 };
 
 module.exports = {
-  createOrEditRule,
+  eventBridgePutRule,
   addTargetLambda,
   addLambdaPermissions,
 };

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -78,16 +78,26 @@ async function addNewTestAlert(testId, alertChannel) {
 }
 
 async function addNewTestAlerts(testId, alertChannels) {
-	///if no alerts then don't attempt 
-	if (alertChannels) {
-		try {
-			// eslint-disable-next-line max-len
-			const result = await Promise.all(alertChannels.map((channel) => addNewTestAlert(testId, channel)));
-			console.log('Add New Test Alerts Result: ', result);
-		} catch (e) {
-			console.error(e);
-		}
-	}
+  if (alertChannels) {
+    try {
+      // eslint-disable-next-line max-len
+      const result = await Promise.all(alertChannels.map((channel) => addNewTestAlert(testId, channel)));
+      console.log('Add New Test Alerts Result: ', result);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+}
+
+async function editTestAlerts(testId, alertChannels) {
+  const query = `
+    DELETE FROM tests_alerts WHERE test_id = ${testId}
+  `;
+  const result = await dbQuery(query);
+  if (result.rowCount >= 1) {
+    addNewTestAlerts(testId, alertChannels);
+  }
+  return true;
 }
 
 async function addNewTestAssertions(testId, assertions) {
@@ -107,6 +117,18 @@ async function addNewTestAssertions(testId, assertions) {
   return true;
 }
 
+async function editTestAssertions(testId, assertions) {
+  const query = `
+    DELETE FROM assertions WHERE test_id = ${testId}
+  `;
+  const result = await dbQuery(query);
+
+  if (result.rowCount >= 1) {
+    addNewTestAssertions(testId, assertions);
+  }
+  return true;
+}
+
 async function addNewTest(ruleName, RuleArn, test) {
   const { minutesBetweenRuns, httpRequest, alertChannels } = test;
   const query = `
@@ -115,14 +137,31 @@ async function addNewTest(ruleName, RuleArn, test) {
     RETURNING id
   `;
 
-  const result = await dbQuery(
-    query,
-  );
+  const result = await dbQuery(query);
 
   if (result.rowCount === 1) {
     const { id: testId } = result.rows[0];
     addNewTestAssertions(testId, httpRequest.assertions);
     addNewTestAlerts(testId, alertChannels);
+  }
+  return false;
+}
+
+async function editTest(ruleName, RuleArn, test) {
+  const { minutesBetweenRuns, httpRequest, alertChannels } = test;
+  const query = `
+    UPDATE tests 
+    SET run_frequency_mins = ${minutesBetweenRuns}
+    WHERE name = '${ruleName}'
+    RETURNING id
+  `;
+
+  const result = await dbQuery(query);
+
+  if (result.rowCount === 1) {
+    const { id: testId } = result.rows[0];
+    editTestAssertions(testId, httpRequest.assertions);
+    editTestAlerts(testId, alertChannels);
   }
   return false;
 }
@@ -215,11 +254,11 @@ async function getTestBody(testId) {
     `;
 
   const testCofnig = await dbQuery(query1);
-	console.log('query1');
+  console.log('query1');
   const assertions = await dbQuery(query2);
-	console.log('query2');
+  console.log('query2');
   const locations = await dbQuery(query3);
-	console.log('query3'); 
+  console.log('query3');
 
   // eslint-disable-next-line object-curly-newline
   const { name, frequency, headers, body, url, method } = testCofnig.rows[0];
@@ -231,7 +270,7 @@ async function getTestBody(testId) {
       minutesBetweenRuns: frequency,
       type: 'api',
       httpRequest: {
-        method: method,
+        method,
         url,
         headers: headers || {},
         body: body || {},
@@ -295,20 +334,10 @@ async function getTestsRuns(id) {
   return json;
 }
 
-async function getEbRuleArn(testId) {
-  const query = `
-    SELECT eb_rule_arn 
-    FROM tests 
-    WHERE id = $1
-  `;
-  const result = await dbQuery(query, testId);
-  return result.rows[0].eb_rule_arn;
-}
-
 module.exports.addNewTest = addNewTest;
 module.exports.getTests = getTests;
 module.exports.getTest = getTest;
 module.exports.getSideload = getSideload;
 module.exports.getTestBody = getTestBody;
 module.exports.getTestsRuns = getTestsRuns;
-module.exports.getEbRuleArn = getEbRuleArn;
+module.exports.editTest = editTest;


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>

This PR:

- renames some functions for clarity
- refactors the previous PR in order to limit code duplication. 
-- The AWS actions is the same for creating a test as it is for editing a test.
-- However, The DB operation for creating a test is different from editing a test
--  To take advantage of this `createOrEditEbRule` function in `testsController` now accepts a second argument `operationType` that dictates which DB method is called

Note on the DB query approach: when editing a test, two functions are called `editTestAlerts` and `editTestAssertions`. Both functions 1) call a query that deletes all existing alerts/  assertions related to the test being edited and then 2) create new alerts and assertions from scratch.

## E2E Testing:

The following request successfully creates a new test:
`POST http://localhost:5001/api/tests` 
request body: (note the `minutesBetweenRuns` = 2)
```
{
  "test": {
    "title": "tim-postman-test-524",
    "locations": [
        "us-east-1",
        "us-west-1",
        "ca-central-1",
        "eu-north-1"
    ],
    "minutesBetweenRuns": "2",
    "type": "api",
    "httpRequest": {
      "method": "get",
      "url": "https://stark-plains-24612.herokuapp.com/api/persons",
      "headers": {},
      "body": {},
      "assertions": [
      {
        "type": "responseTime",
        "property": "",
        "comparison": "lessThan",
        "target": "400"
      },
      {
        "type": "statusCode",
        "property": "",
        "comparison": "equalTo",
        "target": "200"
      }
    ]
    },
    "alertChannels": [
      {
        "type": "discord",
        "destination": "https://discord.com/api/webhooks/999824136513798254/-tZUo-kvKnBFJB9b0htqMu2zgaWA2CA_da1h8O3H6AgLYP_E4FpOe6sczmuqc9vpJ703",
        "alertsOnRecovery": false,
        "alertsOnFailure": true
      }
    ]
  }
}
```

The following request successfully updates the existing test, changing `minutesBetweenRuns` to 1
`PUT http://localhost:5001/api/tests/:id`

request body: (note the `minutesBetweenRuns` = 1; everything else is the same)

```
{
  "test": {
    "title": "tim-postman-test-524",
    "locations": [
        "us-east-1",
        "us-west-1",
        "ca-central-1",
        "eu-north-1"
    ],
    "minutesBetweenRuns": "1",
    "type": "api",
    "httpRequest": {
      "method": "get",
      "url": "https://stark-plains-24612.herokuapp.com/api/persons",
      "headers": {},
      "body": {},
      "assertions": [
      {
        "type": "responseTime",
        "property": "",
        "comparison": "lessThan",
        "target": "400"
      },
      {
        "type": "statusCode",
        "property": "",
        "comparison": "equalTo",
        "target": "200"
      }
    ]
    },
    "alertChannels": [
      {
        "type": "discord",
        "destination": "https://discord.com/api/webhooks/999824136513798254/-tZUo-kvKnBFJB9b0htqMu2zgaWA2CA_da1h8O3H6AgLYP_E4FpOe6sczmuqc9vpJ703",
        "alertsOnRecovery": false,
        "alertsOnFailure": true
      }
    ]
  }
}
```
![Screen Shot 2022-07-28 at 5 42 52 PM](https://user-images.githubusercontent.com/72320460/181654979-c435683e-5255-43b5-8d12-98bb93ab125a.jpg)


