### PR TITLE
Edit test endpoint

### DIFF
--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -1,7 +1,14 @@
 const axios = require('axios');
 const { validationResult } = require('express-validator');
 const { RULE_TARGET_INFO } = require('../constants/aws/locationMappings');
-const { createOrEditRule, addTargetLambda, addLambdaPermissions, removeRule, removePermission, removeTarget } = require('../lib/aws/eventBridgeActions');
+const {
+  putTestRule,
+  addTargetLambda,
+  addLambdaPermissions,
+  removeRule,
+  removePermission,
+  removeTarget,
+} = require('../lib/aws/eventBridgeActions');
 const DB = require('../lib/db/query');
 const queries = require('../lib/db/queries');
 const { modelToEntityTest, entityToJsonTests, entityToJsonTest } = require('../mappers/test');
@@ -14,7 +21,7 @@ const createEventBridgeRule = async (reqBody) => {
   let targetResponse;
   let permissionsResponse;
   try {
-    const { RuleArn } = await createOrEditRule({
+    const { RuleArn } = await putTestRule({
       name: `${test.title}`,
       minutesBetweenRuns: test.minutesBetweenRuns,
     });
@@ -44,35 +51,26 @@ const createEventBridgeRule = async (reqBody) => {
   return { targetResponse, permissionsResponse };
 };
 
-const editEventBridgeRule = async (testId, reqBody) => {
-  const { test } = reqBody;
-  // let targetResponse;
-
-  try {
-    const ebRuleArn = await DB.getEbRuleArn(testId);
-    // EB: edit rule minutesBetweenRuns
-    // note: EB does not allow test name to be edited
-    const { RuleArn } = await createOrEditRule({
-      name: `${test.title}`,
-      minutesBetweenRuns: test.minutesBetweenRuns,
-    });
-    console.log('Existing ARN: ', ebRuleArn);
-    console.log('New EB Arn: ', RuleArn);
-
-    // LAMBDA: edit all other test properties
-  } catch (err) {
-    console.log('Error: ', err);
-    return err;
-  }
-  // return targetResponse
-};
-
 const createTest = async (req, res) => {
   const errors = validationResult(req);
   if (errors.isEmpty()) {
     try {
       await createEventBridgeRule(req.body);
       res.status(201).send(`Test ${req.body.test.title} created`);
+    } catch (err) {
+      console.log('Error: ', err);
+    }
+  } else {
+    res.status(400).json({ errors: errors.array() });
+  }
+};
+
+const editTest = async (req, res) => {
+  const errors = validationResult(req);
+  if (errors.isEmpty()) {
+    try {
+      await editEventBridgeRule(req.body);
+      res.status(200).send(`Test ${req.body.test.title} updated`);
     } catch (err) {
       console.log('Error: ', err);
     }
@@ -175,7 +173,7 @@ const getTestRun = async (req, res) => {
   }
 };
 
-
+// eslint-disable-next-line consistent-return
 const deleteTest = async (req, res) => {
   try {
     const testId = req.params.id;
@@ -199,21 +197,6 @@ const deleteTest = async (req, res) => {
     res.status(200).send('OK');
   } catch (err) {
     console.log('Error: ', err);
-  }
-};
- 
-const editTest = async (req, res) => {
-  const errors = validationResult(req);
-  if (errors.isEmpty()) {
-    const testId = req.params.id;
-    try {
-      await editEventBridgeRule(testId, req.body);
-      res.status(200).send(`Test ${req.body.test.title} updated`);
-    } catch (err) {
-      console.log('Error: ', err);
-    }
-  } else {
-    res.status(400).json({ errors: errors.array() });
   }
 };
 

--- a/lib/aws/eventBridgeActions.js
+++ b/lib/aws/eventBridgeActions.js
@@ -1,8 +1,13 @@
-const { PutRuleCommand, PutTargetsCommand, DeleteRuleCommand, RemoveTargetsCommand } = require('@aws-sdk/client-eventbridge');
+const {
+  PutRuleCommand,
+  PutTargetsCommand,
+  DeleteRuleCommand,
+  RemoveTargetsCommand,
+} = require('@aws-sdk/client-eventbridge');
 const { ebClient } = require('./eventBridgeClient');
 const { lambdaClient, AddPermissionCommand, RemovePermissionCommand } = require('./lambdaClient');
 
-const createOrEditRule = async ({ name, minutesBetweenRuns }) => {
+const putTestRule = async ({ name, minutesBetweenRuns }) => {
   const params = {
     Name: name,
     ScheduleExpression: String(minutesBetweenRuns) === '1' ? 'rate(1 minute)' : `rate(${minutesBetweenRuns} minutes)`,
@@ -74,6 +79,7 @@ const removeTarget = async ({ lambdaName, testName }) => {
   try {
     const data = await ebClient.send(new RemoveTargetsCommand(params));
     console.log('Success, target removed:', data);
+    return data;
   } catch (err) {
     console.log('Error', err);
     return err;
@@ -88,6 +94,7 @@ const removeRule = async (ruleName) => {
   try {
     const data = await ebClient.send(new DeleteRuleCommand(params));
     console.log('Success, rule delete:', data);
+    return data;
   } catch (err) {
     console.log('Error', err);
     return err;
@@ -110,7 +117,7 @@ const removePermission = async ({ statementId, lambdaArn }) => {
 };
 
 module.exports = {
-  createOrEditRule,
+  putTestRule,
   addTargetLambda,
   addLambdaPermissions,
   removeRule,

--- a/lib/aws/eventBridgeActions.js
+++ b/lib/aws/eventBridgeActions.js
@@ -16,7 +16,7 @@ const putTestRule = async ({ name, minutesBetweenRuns }) => {
 
   try {
     const data = await ebClient.send(new PutRuleCommand(params));
-    console.log('Success, scheduled rule created; Rule ARN:', data);
+    console.log('Success, scheduled rule created/ modified; Rule ARN:', data);
     return data; // For unit tests. (not important right now)
   } catch (err) {
     console.log('Error', err);

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -78,16 +78,15 @@ async function addNewTestAlert(testId, alertChannel) {
 }
 
 async function addNewTestAlerts(testId, alertChannels) {
-	///if no alerts then don't attempt 
-	if (alertChannels) {
-		try {
-			// eslint-disable-next-line max-len
-			const result = await Promise.all(alertChannels.map((channel) => addNewTestAlert(testId, channel)));
-			console.log('Add New Test Alerts Result: ', result);
-		} catch (e) {
-			console.error(e);
-		}
-	}
+  if (alertChannels) {
+    try {
+      // eslint-disable-next-line max-len
+      const result = await Promise.all(alertChannels.map((channel) => addNewTestAlert(testId, channel)));
+      console.log('Add New Test Alerts Result: ', result);
+    } catch (e) {
+      console.error(e);
+    }
+  }
 }
 
 async function addNewTestAssertions(testId, assertions) {
@@ -125,6 +124,10 @@ async function addNewTest(ruleName, RuleArn, test) {
     addNewTestAlerts(testId, alertChannels);
   }
   return false;
+}
+
+async function editTest(ruleName, RuleArn, test) {
+  console.log('HELLO FROM DB.editTest!!!');
 }
 
 async function getTests() {
@@ -228,7 +231,7 @@ async function getTestBody(testId) {
       minutesBetweenRuns: frequency,
       type: 'api',
       httpRequest: {
-        method: method,
+        method,
         url,
         headers: headers || {},
         body: body || {},
@@ -326,4 +329,4 @@ module.exports.getTestsRuns = getTestsRuns;
 module.exports.getTestName = getTestName;
 module.exports.deleteTest = deleteTest;
 module.exports.getEbRuleArn = getEbRuleArn;
-
+module.exports.editTest = editTest;

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -127,7 +127,13 @@ async function addNewTest(ruleName, RuleArn, test) {
 }
 
 async function editTest(ruleName, RuleArn, test) {
-  console.log('HELLO FROM DB.editTest!!!');
+  const updateTestsQuery = `
+    UPDATE tests 
+    SET run_frequency_mins = $1
+    WHERE name = $2
+  `;
+  const result = await dbQuery(updateTestsQuery, test.minutesBetweenRuns, ruleName);
+  return result.rows;
 }
 
 async function getTests() {
@@ -310,16 +316,6 @@ async function deleteTest(testId) {
   console.log('deleted data', data);
 }
 
-async function getEbRuleArn(testId) {
-  const query = `
-    SELECT eb_rule_arn 
-    FROM tests 
-    WHERE id = $1
-  `;
-  const result = await dbQuery(query, testId);
-  return result.rows[0].eb_rule_arn;
-}
-
 module.exports.addNewTest = addNewTest;
 module.exports.getTests = getTests;
 module.exports.getTest = getTest;
@@ -328,5 +324,4 @@ module.exports.getTestBody = getTestBody;
 module.exports.getTestsRuns = getTestsRuns;
 module.exports.getTestName = getTestName;
 module.exports.deleteTest = deleteTest;
-module.exports.getEbRuleArn = getEbRuleArn;
 module.exports.editTest = editTest;


### PR DESCRIPTION
This PR add the following functionality:

- edit the test run interval for an existing test

## E2E testing:

### Existing Test:
![Screen Shot 2022-07-28 at 8 37 42 PM](https://user-images.githubusercontent.com/72320460/181671244-0f1d78a2-9f26-4e03-a786-60aa26bc9e5f.jpg)
![Screen Shot 2022-07-28 at 8 37 54 PM](https://user-images.githubusercontent.com/72320460/181671272-df6d5100-110d-4194-b0e1-e8bae9a2c0bb.jpg)

### PUT Request (updates `minutesBetweenRuns` only):

![Screen Shot 2022-07-28 at 8 39 12 PM](https://user-images.githubusercontent.com/72320460/181671415-ba914bfe-6b8e-48c4-88d5-32f029cbad37.jpg)

### Results in the following updates to AWS and DB:

![Screen Shot 2022-07-28 at 8 40 47 PM](https://user-images.githubusercontent.com/72320460/181671586-f319e1be-5017-44ba-af30-7911d7d1c1e6.jpg)

![Screen Shot 2022-07-28 at 8 41 04 PM](https://user-images.githubusercontent.com/72320460/181671641-8547ab7a-fe1c-4843-aa77-e8627153b042.jpg)

