### PR TITLE
refactor location mapping variables to env variables

### DIFF
--- a/constants/aws/locationMappings.js
+++ b/constants/aws/locationMappings.js
@@ -1,6 +1,9 @@
+require('dotenv').config();
+
 module.exports.RULE_TARGET_INFO = {
   'test-route-packager': {
-    arn: 'arn:aws:lambda:us-east-1:082057163641:function:test-route-packager',
-    title: 'test-route-packager',
+    arn: process.env.TEST_ROUTE_PACKAGER_ARN,
+    title: process.env.TEST_ROUTE_PACKAGER_NAME,
+    url: process.env.TEST_ROUTE_PACKAGER_URL,
   },
 };

--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -154,7 +154,7 @@ const runNow = async (req, res) => {
   try {
     const testId = req.params.id;
     // this url will need to come from a config file
-    const lambdaURL = 'https://x3a5z6dcrihrt5dzirl3c6lube0wrlys.lambda-url.us-east-1.on.aws/';
+    const lambdaURL = RULE_TARGET_INFO['test-route-packager'].url;
     const data = await DB.getTestBody(testId);
     axios.post(lambdaURL, data);
     res.status(200).send('OK');


### PR DESCRIPTION
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>

This PR: 
- refactoring the code to accept the following environmental variables: 
    - TEST_ROUTE_PACKAGER_URL="https://x3a5z6dcrihrt5dzirl3c6lube0wrlys.lambda-url.us-east-1.on.aws/"
    - TEST_ROUTE_PACKAGER_ARN="arn:aws:lambda:us-east-1:082057163641:function:test-route-packager"
    - TEST_ROUTE_PACKAGER_NAME=test-route-packager
 (add it to your .env)