### PR TITLE
return new tests with no runs from get tests endpoint

### DIFF
--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -137,8 +137,10 @@ const getTests = async (req, res) => {
         tests.addTest(test);
       }
       const testRun = modelToEntityTestRun(t);
-      const testRunTest = tests.getTest(testRun.testId);
-      testRunTest.addRun(testRun);
+      if (testRun) {
+        const testRunTest = tests.getTest(testRun.testId);
+        testRunTest.addRun(testRun);
+      }
     });
     const testsJson = entityToJsonTests(tests);
     res.status(200).json(testsJson);

--- a/lib/db/queries/getAllTests.js
+++ b/lib/db/queries/getAllTests.js
@@ -21,7 +21,7 @@ async function getAllTests() {
       rtr.rank run_rank,
       rtr.created_at AS run_created_at
   FROM tests t 
-  JOIN ranked_test_runs rtr ON rtr.test_id = t.id AND rtr.rank <= 3
+  LEFT JOIN ranked_test_runs rtr ON rtr.test_id = t.id AND rtr.rank <= 3
   ORDER BY test_id, rank ASC
   `;
 

--- a/mappers/testRun.js
+++ b/mappers/testRun.js
@@ -1,20 +1,24 @@
 const TestRun = require('../entities/TestRun');
 const { entityToJsonAssertion } = require('./assertion');
 
-const modelToEntityTestRun = (testRunData) => new TestRun({
-  id: testRunData.run_id,
-  testId: testRunData.test_id,
-  success: testRunData.run_success,
-  createdAt: testRunData.run_created_at,
-  completedAt: testRunData.run_completed_at,
-  regionName: testRunData.run_region_name,
-  regionDisplayName: testRunData.run_region_display_name,
-  regionFlagUrl: testRunData.run_region_flag_url,
-  responseTime: testRunData.run_response_time,
-  responseStatus: testRunData.run_response_status,
-  responseBody: testRunData.run_response_body,
-  responseHeaders: testRunData.run_response_headers,
-});
+const modelToEntityTestRun = (testRunData) => {
+  if (testRunData.run_id) {
+    return new TestRun({
+      id: testRunData.run_id,
+      testId: testRunData.test_id,
+      success: testRunData.run_success,
+      createdAt: testRunData.run_created_at,
+      completedAt: testRunData.run_completed_at,
+      regionName: testRunData.run_region_name,
+      regionDisplayName: testRunData.run_region_display_name,
+      regionFlagUrl: testRunData.run_region_flag_url,
+      responseTime: testRunData.run_response_time,
+      responseStatus: testRunData.run_response_status,
+      responseBody: testRunData.run_response_body,
+      responseHeaders: testRunData.run_response_headers,
+    });
+  }
+};
 
 const entityToJsonTestRun = (testRunEntity) => ({
   id: testRunEntity.id,


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR: 
* Removes the inner join from the query powering `GET /api/tests` so that even tests with zero runs will be returned by this endpoint

# Validation
Sent a `POST /api/tests` for a new test with name `0729-t1` to my local `tests-crud`. Then immediately made a `GET /api/tests` request and saw this as part of the response: 

<img width="692" alt="Screen Shot 2022-07-29 at 12 11 53 PM" src="https://user-images.githubusercontent.com/30358327/181828573-ebd699b5-3430-49d4-ab03-730f8284155e.png">

