### PR TITLE
add test id and assertion ids to payload sent to event bridge

### DIFF
--- a/lib/db/queries/addNewTest.js
+++ b/lib/db/queries/addNewTest.js
@@ -1,0 +1,25 @@
+const { dbQuery } = require('../conn');
+
+// TODO: Move to db lookup
+const httpMethodIds = {
+  get: 1,
+  post: 2,
+  put: 3,
+  delete: 4,
+  patch: 5,
+  head: 6,
+};
+
+async function addNewTest(test) {
+  const { minutesBetweenRuns, httpRequest } = test;
+  const query = `
+    INSERT INTO tests (name, run_frequency_mins, method_id, url, status) 
+    VALUES ('${test.title}', '${minutesBetweenRuns}', '${httpMethodIds[httpRequest.method]}', '${httpRequest.url}', 'enabled')
+    RETURNING id
+  `;
+
+  const result = await dbQuery(query);
+  return result.rows[0];
+}
+
+module.exports = addNewTest;

--- a/lib/db/queries/addTestAlerts.js
+++ b/lib/db/queries/addTestAlerts.js
@@ -1,0 +1,61 @@
+const { dbQuery } = require('../conn');
+
+async function addNewTestAlert(testId, alertChannel) {
+  const query1 = `
+    INSERT INTO notification_settings (alerts_on_recovery, alerts_on_failure)
+    VALUES ($1, $2)
+    RETURNING id
+  `;
+
+  const query2 = `
+    INSERT INTO alerts (type, destination, notification_settings_id)
+    VALUES ($1, $2, $3)
+    RETURNING id
+  `;
+
+  const query3 = `
+    INSERT INTO tests_alerts (test_id, alerts_id)
+    VALUES ($1, $2)
+  `;
+
+  let notificationSettingsId;
+  let alertsId;
+  let addAlertResult = false;
+
+  try {
+    const result1 = await dbQuery(
+      query1,
+      alertChannel.alertsOnRecovery,
+      alertChannel.alertsOnFailure,
+    );
+    notificationSettingsId = result1.rows[0].id;
+
+    const result2 = await dbQuery(
+      query2,
+      alertChannel.type,
+      alertChannel.destination,
+      notificationSettingsId,
+    );
+    alertsId = result2.rows[0].id;
+
+    const result3 = await dbQuery(query3, testId, alertsId);
+    addAlertResult = result3.rowCount === 1;
+  } catch (e) {
+    console.error(e);
+  }
+  return addAlertResult;
+}
+
+async function addNewTestAlerts(testId, alertChannels) {
+  if (alertChannels) {
+    try {
+      // eslint-disable-next-line max-len
+      const result = await Promise.all(alertChannels.map((channel) => addNewTestAlert(testId, channel)));
+      console.log('Add New Test Alerts Result: ', result);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+}
+
+module.exports = addNewTestAlerts;

--- a/lib/db/queries/addTestAssertions.js
+++ b/lib/db/queries/addTestAssertions.js
@@ -1,0 +1,20 @@
+const { comparisonTypeToId } = require('../../../utils/helpers');
+const { dbQuery } = require('../conn');
+
+async function addNewTestAssertions(testId, assertions) {
+  let query = `
+    INSERT INTO assertions (test_id, type, property, comparison_type_id, expected_value)
+    VALUES
+  `;
+  assertions.forEach((assertion) => {
+    const comparisonId = comparisonTypeToId(assertion.comparison);
+    query += `(${testId}, '${assertion.type}', '${assertion.property || null}', ${comparisonId}, '${assertion.target || null}'),`;
+  });
+
+  let queryCopy = query.slice(0, query.length - 1).replace(/'null'/g, null);
+  queryCopy += ' RETURNING id, type, property, comparison_type_id, expected_value;';
+  const result = await dbQuery(queryCopy);
+  return result.rows;
+}
+
+module.exports = addNewTestAssertions;

--- a/lib/db/queries/index.js
+++ b/lib/db/queries/index.js
@@ -1,5 +1,8 @@
 const getAllTests = require('./getAllTests');
 const getTestRuns = require('./getTestRuns');
+const addNewTest = require('./addNewTest');
+const addTestAssertions = require('./addTestAssertions');
+const addTestAlerts = require('./addTestAlerts');
 
 // enables imports elsewhere under a common namespace
 //
@@ -10,4 +13,7 @@ const getTestRuns = require('./getTestRuns');
 module.exports = {
   getAllTests,
   getTestRuns,
+  addNewTest,
+  addTestAssertions,
+  addTestAlerts,
 };

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -1,131 +1,6 @@
 const { dbQuery } = require('./conn');
 const helpers = require('../../utils/helpers');
 
-// TODO: Move to db lookup
-const comparisonIds = {
-  equalTo: 1,
-  notEqualTo: 2,
-  greaterThan: 3,
-  lessThan: 4,
-  greaterThanOrEqualTo: 5,
-  lessThanOrEqualTo: 6,
-  hasKey: 7,
-  notHasKey: 8,
-  hasValue: 9,
-  notHasValue: 10,
-  isEmpty: 11,
-  isNotEmpty: 12,
-  contains: 13,
-  notContains: 14,
-  isNull: 15,
-  isNotNull: 16,
-};
-
-// TODO: Move to db lookup
-const httpMethodIds = {
-  get: 1,
-  post: 2,
-  put: 3,
-  delete: 4,
-  patch: 5,
-  head: 6,
-};
-
-async function addNewTestAlert(testId, alertChannel) {
-  const query1 = `
-    INSERT INTO notification_settings (alerts_on_recovery, alerts_on_failure)
-    VALUES ($1, $2)
-    RETURNING id
-  `;
-
-  const query2 = `
-    INSERT INTO alerts (type, destination, notification_settings_id)
-    VALUES ($1, $2, $3)
-    RETURNING id
-  `;
-
-  const query3 = `
-    INSERT INTO tests_alerts (test_id, alerts_id)
-    VALUES ($1, $2)
-  `;
-
-  let notificationSettingsId;
-  let alertsId;
-  let addAlertResult = false;
-
-  try {
-    const result1 = await dbQuery(
-      query1,
-      alertChannel.alertsOnRecovery,
-      alertChannel.alertsOnFailure,
-    );
-    notificationSettingsId = result1.rows[0].id;
-
-    const result2 = await dbQuery(
-      query2,
-      alertChannel.type,
-      alertChannel.destination,
-      notificationSettingsId,
-    );
-    alertsId = result2.rows[0].id;
-
-    const result3 = await dbQuery(query3, testId, alertsId);
-    addAlertResult = result3.rowCount === 1;
-  } catch (e) {
-    console.error(e);
-  }
-  return addAlertResult;
-}
-
-async function addNewTestAlerts(testId, alertChannels) {
-  if (alertChannels) {
-    try {
-      // eslint-disable-next-line max-len
-      const result = await Promise.all(alertChannels.map((channel) => addNewTestAlert(testId, channel)));
-      console.log('Add New Test Alerts Result: ', result);
-    } catch (e) {
-      console.error(e);
-    }
-  }
-}
-
-async function addNewTestAssertions(testId, assertions) {
-  let query = `
-    INSERT INTO assertions (test_id, type, property, comparison_type_id, expected_value)
-    VALUES
-  `;
-  assertions.forEach((assertion) => {
-    const comparisonId = comparisonIds[assertion.comparison];
-    query += `(${testId}, '${assertion.type}', '${assertion.property || null}', ${comparisonId}, '${assertion.target || null}'),`;
-  });
-
-  let queryCopy = query.slice(0, query.length - 1).replace(/'null'/g, null);
-  queryCopy += ';';
-  const result = await dbQuery(queryCopy);
-  if (result.rowCount === 0) return false;
-  return true;
-}
-
-async function addNewTest(ruleName, RuleArn, test) {
-  const { minutesBetweenRuns, httpRequest, alertChannels } = test;
-  const query = `
-    INSERT INTO tests (name, run_frequency_mins, method_id, url, status, eb_rule_arn) 
-    VALUES ('${ruleName}', '${minutesBetweenRuns}', '${httpMethodIds[httpRequest.method]}', '${httpRequest.url}', 'enabled', '${RuleArn}')
-    RETURNING id
-  `;
-
-  const result = await dbQuery(
-    query,
-  );
-
-  if (result.rowCount === 1) {
-    const { id: testId } = result.rows[0];
-    addNewTestAssertions(testId, httpRequest.assertions);
-    addNewTestAlerts(testId, alertChannels);
-  }
-  return false;
-}
-
 async function editTest(ruleName, RuleArn, test) {
   const updateTestsQuery = `
     UPDATE tests 
@@ -316,7 +191,6 @@ async function deleteTest(testId) {
   console.log('deleted data', data);
 }
 
-module.exports.addNewTest = addNewTest;
 module.exports.getTests = getTests;
 module.exports.getTest = getTest;
 module.exports.getSideload = getSideload;

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -72,8 +72,52 @@ const formatRuns = (runs, assertionResults) => {
   return testRuns;
 };
 
+const comparisonTypeToId = (type) => {
+  return {
+    equalTo: 1,
+    notEqualTo: 2,
+    greaterThan: 3,
+    lessThan: 4,
+    greaterThanOrEqualTo: 5,
+    lessThanOrEqualTo: 6,
+    hasKey: 7,
+    notHasKey: 8,
+    hasValue: 9,
+    notHasValue: 10,
+    isEmpty: 11,
+    isNotEmpty: 12,
+    contains: 13,
+    notContains: 14,
+    isNull: 15,
+    isNotNull: 16,
+  }[type];
+};
+
+const comparisonIdToType = (id) => {
+  return {
+    1: 'equalTo',
+    2: 'notEqualTo',
+    3: 'greaterThan',
+    4: 'lessThan',
+    5: 'greaterThanOrEqualTo',
+    6: 'lessThanOrEqualTo',
+    7: 'hasKey',
+    8: 'notHasKey',
+    9: 'hasValue',
+    10: 'notHasValue',
+    11: 'isEmpty',
+    12: 'isNotEmpty',
+    13: 'contains',
+    14: 'notContains',
+    15: 'isNull',
+    16: 'isNotNull',
+  }[id];
+};
+
 module.exports.snakeToCamel = snakeToCamel;
 module.exports.toCamelCase = toCamelCase;
 module.exports.toDash = toDash;
 module.exports.formatAssertions = formatAssertions;
 module.exports.formatRuns = formatRuns;
+module.exports.comparisonTypeToId = comparisonTypeToId;
+module.exports.comparisonIdToType = comparisonIdToType;


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR: 
* Extracts the test/assertion/alert queries into dedicated files
* Enables writes to the database before creating a rule in event bridge 
* Enables attaching the test id and assertion ids to the test configuration sent to event bridge

# Validation
Created a config in the UI locally (and configured to send requests to my locally running `tests-crud`) and saved. A config with this target showed up in EventBridge:

<img width="542" alt="Screen Shot 2022-07-30 at 9 21 37 PM" src="https://user-images.githubusercontent.com/30358327/182009957-9620a519-d97a-4104-b964-cf586aecf96b.png">

Results showed up in the UI:

<img width="1018" alt="Screen Shot 2022-07-30 at 9 24 09 PM" src="https://user-images.githubusercontent.com/30358327/182009980-6a41218e-9204-4792-8925-9d1918512f81.png">

I created a test with the same response time assertion and a Discord alert and alerts showed up: 

<img width="619" alt="Screen Shot 2022-07-30 at 9 28 05 PM" src="https://user-images.githubusercontent.com/30358327/182010093-a711f8c4-04d2-453c-87cd-c25e84ad8571.png">





