### PR TITLE
add column to assertions table to track whether an assertion is being used by the current config

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -137,6 +137,7 @@ CREATE TABLE assertions (
     REFERENCES comparison_types (id)
     ON DELETE CASCADE,
   expected_value text,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMP
 ); 


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR adds a new column to the assertions table. This column, 'active', will be used for the implementation of edit test functionality. Old, overwritten assertions will have their 'active' value flipped to false. 

# Validation
Ran these four commands in the DB: 
```
ALTER TABLE assertions ADD COLUMN active BOOLEAN;
UPDATE assertions SET active = true;
ALTER TABLE assertions ALTER COLUMN active SET NOT NULL;
ALTER TABLE assertions ALTER COLUMN active SET DEFAULT TRUE;
```

I then created a config and verified that a new row was added to the assertions table with an 'active' value of true:

<img width="639" alt="Screen Shot 2022-07-31 at 10 34 22 AM" src="https://user-images.githubusercontent.com/30358327/182038508-4d337717-870c-4b09-a41e-cd272092e138.png">

