### PR TITLE
enable updating of full test configuration

### DIFF
--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -96,12 +96,6 @@ const editEventBridgeRule = async (reqBody) => {
       lambdaName: RULE_TARGET_INFO['test-route-packager'].title,
       inputJSON: JSON.stringify(reqBody),
     });
-
-    try {
-      await DB.editTest(ruleName, RuleArn, test);
-    } catch (err) {
-      throw new Error('Error: ', err);
-    }
   } catch (err) {
     console.log('Error: ', err);
     return err;
@@ -113,6 +107,14 @@ const editTest = async (req, res) => {
   const errors = validationResult(req);
   if (errors.isEmpty()) {
     try {
+      const { test } = req.body;
+      const { id: testId } = await queries.editTest(test);
+      test.id = testId;
+      await queries.deactivateTestAssertions(testId);
+      const assertionsData = await queries.addTestAssertions(testId, test.httpRequest.assertions);
+      assignAssertionIds(test.httpRequest.assertions, assertionsData);
+      await queries.deleteTestAlerts(testId);
+      await queries.addTestAlerts(testId, test.alertChannels);
       await editEventBridgeRule(req.body);
       res.status(200).send(`Test ${req.body.test.title} updated`);
     } catch (err) {

--- a/docs/api.md
+++ b/docs/api.md
@@ -52,49 +52,52 @@ Creates a synthetic test
 
 ```json
 {
-  "test": {
-    "title": "New-UI-test",
-    "locations": [
-        "us-east-1",
-        "us-west-1",
-        "ca-central-1",
-        "eu-north-1"
-    ],
-    "minutesBetweenRuns": "1",
-    "type": "api",
-    "httpRequest": {
-      "method": "get",
-      "url": "https://trellific.corkboard.dev/api/boards",
-      "headers": {},
-      "body": {},
-      "assertions": [
-      {
-        "type": "responseTime",
-        "property": "",
-        "comparison": "lessThan",
-        "target": "500"
-      },
-      {
-        "type": "statusCode",
-        "property": "",
-        "comparison": "equalTo",
-        "target": "200"
-      },
-      {
-        "type": "header",
-        "property": "access-control-allow-origin",
-        "comparison": "equalTo",
-        "target": "*"
-      },
-      {
-        "type": "body",
-        "property": "",
-        "comparison": "contains",
-        "target": "_id"
-      }
-    ]
+    "test": {
+        "title": "0731-t2",
+        "locations": [
+            "us-east-1"
+        ],
+        "minutesBetweenRuns": "60",
+        "type": "api",
+        "httpRequest": {
+            "method": "get",
+            "url": "https://trellific.corkboard.dev/api/boards",
+            "headers": {
+                "Content-Type": "application/json"
+            },
+            "body": {
+                "board": {
+                    "title": "0731-t3 board"
+                }
+            },
+            "assertions": [
+                {
+                    "type": "responseTime",
+                    "property": "",
+                    "comparison": "lessThan",
+                    "target": "500"
+                },
+                {
+                    "type": "statusCode",
+                    "property": "",
+                    "comparison": "equalTo",
+                    "target": "200"
+                },
+                {
+                    "type": "header",
+                    "property": "access-control-allow-origin",
+                    "comparison": "equalTo",
+                    "target": "*"
+                },
+                {
+                    "type": "body",
+                    "property": "",
+                    "comparison": "contains",
+                    "target": "_id"
+                }
+            ]
+        }
     }
-  }
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,9 +35,14 @@
     + [1.6.1. Expected payload](#161-expected-payload)
     + [1.6.2. Successful response](#162-successful-response)
       - [1.6.2.1 Example response](#1621-example-response)
-  * [1.7.0. DELETE /api/tests/:testId](#170-delete--api-tests--testid-runs)
-    + [1.7.1. Expected payload](#171-expected-payload)
-    + [1.7.2. Successful response](#172-successful-response)
+  * [1.7.0. DELETE /api/tests/:testId](#170-delete--api-tests--testid)
+    + [1.6.1. Expected payload](#161-expected-payload-1)
+    + [1.6.2. Successful response](#162-successful-response-1)
+  * [1.7. PUT /api/tests/:id](#17-put--api-tests--id)
+    + [1.7.1. Expected Payload](#171-expected-payload)
+    + [1.7.2. Successful Response](#172-successful-response)
+      - [1.7.2.1. Example Response](#1721-example-response)
+      - [1.7.3 Forwarded Payload](#173-forwarded-payload)
 
 <!-- /TOC -->
 <!-- generated using: https://ecotrust-canada.github.io/markdown-toc/ -->
@@ -113,7 +118,7 @@ Test my-new-test created
 
 #### 1.1.3 Forwarded Payload
 
-The payload received from the client (refer to 1.1.1) is forwarded to EventBridge for use as the "Input to Target" JSON without modification.
+The payload received from the client (refer to 1.1.1) is forwarded to EventBridge for use as the "Input to Target" JSON largely without modification (ids are added for the test and assertions).
 
 
 ## 1.2. GET /api/tests
@@ -655,4 +660,82 @@ no playload
 
 200
 
+## 1.7. PUT /api/tests/:id
 
+Edits a test configuration
+
+### 1.7.1. Expected Payload
+
+```json
+{
+    "test": {
+        "title": "0731-t6",
+        "locations": [
+            "us-east-1"
+        ],
+        "minutesBetweenRuns": "5",
+        "type": "api",
+        "httpRequest": {
+            "method": "get",
+            "url": "https://trellific.corkboard.dev/api/boards",
+            "headers": {
+                "Content-Type": "application/json"
+            },
+            "body": {
+                "board": {
+                    "title": "0731-t3 board (edit 1)"
+                }
+            },
+            "assertions": [
+                {
+                    "type": "responseTime",
+                    "property": "",
+                    "comparison": "lessThan",
+                    "target": "500"
+                },
+                {
+                    "type": "statusCode",
+                    "property": "",
+                    "comparison": "equalTo",
+                    "target": "200"
+                },
+                {
+                    "type": "header",
+                    "property": "access-control-allow-origin",
+                    "comparison": "equalTo",
+                    "target": "*"
+                },
+                {
+                    "type": "body",
+                    "property": "",
+                    "comparison": "contains",
+                    "target": "_id"
+                }
+            ]
+        },
+        "alertChannels": [
+            {
+                "id": "94db2374-a765-4f93-9d3b-114fabfa21f0",
+                "type": "discord",
+                "destination": "https://discord.com/api/webhooks/999824136513798254/-tZUo-kvKnBFJB9b0htqMu2zgaWA2CA_da1h8O3H6AgLYP_E4FpOe6sczmuqc9vpJ703",
+                "alertsOnRecovery": false,
+                "alertsOnFailure": true
+            }
+        ]
+    }
+}
+```
+
+### 1.7.2. Successful Response
+
+The new test is returned in JSON format with a 200 response status code.
+
+#### 1.7.2.1. Example Response
+
+```text
+Test my-updated-test updated
+```
+
+#### 1.7.3 Forwarded Payload
+
+The payload received from the client (refer to 1.1.1) is forwarded to EventBridge for use as the "Input to Target" JSON largely without modification (ids are added for the test and assertions).

--- a/lib/db/queries/addNewTest.js
+++ b/lib/db/queries/addNewTest.js
@@ -1,20 +1,11 @@
+const { httpMethodToId } = require('../../../utils/helpers');
 const { dbQuery } = require('../conn');
-
-// TODO: Move to db lookup
-const httpMethodIds = {
-  get: 1,
-  post: 2,
-  put: 3,
-  delete: 4,
-  patch: 5,
-  head: 6,
-};
 
 async function addNewTest(test) {
   const { minutesBetweenRuns, httpRequest } = test;
   const query = `
-    INSERT INTO tests (name, run_frequency_mins, method_id, url, status) 
-    VALUES ('${test.title}', '${minutesBetweenRuns}', '${httpMethodIds[httpRequest.method]}', '${httpRequest.url}', 'enabled')
+    INSERT INTO tests (name, run_frequency_mins, method_id, url, headers, body, status) 
+    VALUES ('${test.title}', '${minutesBetweenRuns}', '${httpMethodToId(httpRequest.method)}', '${httpRequest.url}', '${JSON.stringify(httpRequest.headers)}', '${JSON.stringify(httpRequest.body)}', 'enabled')
     RETURNING id
   `;
 

--- a/lib/db/queries/deactivateTestAssertions.js
+++ b/lib/db/queries/deactivateTestAssertions.js
@@ -1,0 +1,13 @@
+const { dbQuery } = require('../conn');
+
+async function deactivateTestAssertions(testId) {
+  const updateTestAssertionsQuery = `
+    UPDATE assertions 
+    SET active = false 
+    WHERE test_id = '${testId}'
+  `;
+  const result = await dbQuery(updateTestAssertionsQuery);
+  return result.rows;
+}
+
+module.exports = deactivateTestAssertions;

--- a/lib/db/queries/deleteTestAlerts.js
+++ b/lib/db/queries/deleteTestAlerts.js
@@ -1,0 +1,12 @@
+const { dbQuery } = require('../conn');
+
+async function deleteTestAlerts(testId) {
+  const deleteAlertsQuery = `
+    DELETE FROM tests_alerts 
+    WHERE test_id = '${testId}'
+  `;
+  const result = await dbQuery(deleteAlertsQuery);
+  return result.rows;
+}
+
+module.exports = deleteTestAlerts;

--- a/lib/db/queries/editTest.js
+++ b/lib/db/queries/editTest.js
@@ -1,0 +1,22 @@
+const { httpMethodToId } = require('../../../utils/helpers');
+const { dbQuery } = require('../conn');
+
+async function editTest(test) {
+  const { minutesBetweenRuns, httpRequest } = test;
+
+  const updateTestsQuery = `
+    UPDATE tests 
+    SET run_frequency_mins = '${minutesBetweenRuns}', 
+    method_id = '${httpMethodToId(httpRequest.method)}',
+    url = '${httpRequest.url}',
+    headers = '${JSON.stringify(httpRequest.headers)}',
+    body = '${JSON.stringify(httpRequest.body)}',
+    updated_at = NOW()
+    WHERE name = '${test.title}'
+    RETURNING id
+  `;
+  const result = await dbQuery(updateTestsQuery);
+  return result.rows[0];
+}
+
+module.exports = editTest;

--- a/lib/db/queries/index.js
+++ b/lib/db/queries/index.js
@@ -3,6 +3,9 @@ const getTestRuns = require('./getTestRuns');
 const addNewTest = require('./addNewTest');
 const addTestAssertions = require('./addTestAssertions');
 const addTestAlerts = require('./addTestAlerts');
+const editTest = require('./editTest');
+const deactivateTestAssertions = require('./deactivateTestAssertions');
+const deleteTestAlerts = require('./deleteTestAlerts');
 
 // enables imports elsewhere under a common namespace
 //
@@ -16,4 +19,7 @@ module.exports = {
   addNewTest,
   addTestAssertions,
   addTestAlerts,
+  editTest,
+  deactivateTestAssertions,
+  deleteTestAlerts,
 };

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -1,16 +1,6 @@
 const { dbQuery } = require('./conn');
 const helpers = require('../../utils/helpers');
 
-async function editTest(ruleName, RuleArn, test) {
-  const updateTestsQuery = `
-    UPDATE tests 
-    SET run_frequency_mins = $1
-    WHERE name = $2
-  `;
-  const result = await dbQuery(updateTestsQuery, test.minutesBetweenRuns, ruleName);
-  return result.rows;
-}
-
 async function getTests() {
   const query = 'SELECT * FROM tests';
 
@@ -198,4 +188,3 @@ module.exports.getTestBody = getTestBody;
 module.exports.getTestsRuns = getTestsRuns;
 module.exports.getTestName = getTestName;
 module.exports.deleteTest = deleteTest;
-module.exports.editTest = editTest;

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -72,6 +72,17 @@ const formatRuns = (runs, assertionResults) => {
   return testRuns;
 };
 
+const httpMethodToId = (method) => {
+  return {
+    get: 1,
+    post: 2,
+    put: 3,
+    delete: 4,
+    patch: 5,
+    head: 6,
+  }[method];
+};
+
 const comparisonTypeToId = (type) => {
   return {
     equalTo: 1,
@@ -119,5 +130,6 @@ module.exports.toCamelCase = toCamelCase;
 module.exports.toDash = toDash;
 module.exports.formatAssertions = formatAssertions;
 module.exports.formatRuns = formatRuns;
+module.exports.httpMethodToId = httpMethodToId;
 module.exports.comparisonTypeToId = comparisonTypeToId;
 module.exports.comparisonIdToType = comparisonIdToType;


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR enables updating all parts of a test configuration

# Validation
Ran `POST /api/tests` with the following payload: 
```
{
    "test": {
        "title": "0731-t6",
        "locations": [
            "us-east-1"
        ],
        "minutesBetweenRuns": "60",
        "type": "api",
        "httpRequest": {
            "method": "get",
            "url": "https://trellific.corkboard.dev/api/boards",
            "headers": {
                "Content-Type": "application/json"
            },
            "body": {
                "board": {
                    "title": "0731-t3 board"
                }
            },
            "assertions": [
                {
                    "type": "responseTime",
                    "property": "",
                    "comparison": "lessThan",
                    "target": "500"
                },
                {
                    "type": "statusCode",
                    "property": "",
                    "comparison": "equalTo",
                    "target": "200"
                },
                {
                    "type": "header",
                    "property": "access-control-allow-origin",
                    "comparison": "equalTo",
                    "target": "*"
                },
                {
                    "type": "body",
                    "property": "",
                    "comparison": "contains",
                    "target": "_id"
                }
            ]
        }
    }
}
```

Then ran `PUT /api/tests/95` with the following payload: 
```
{
    "test": {
        "title": "0731-t6",
        "locations": [
            "us-east-1"
        ],
        "minutesBetweenRuns": "5",
        "type": "api",
        "httpRequest": {
            "method": "get",
            "url": "https://trellific.corkboard.dev/api/boards",
            "headers": {
                "Content-Type": "application/json"
            },
            "body": {
                "board": {
                    "title": "0731-t3 board (edit 1)"
                }
            },
            "assertions": [
                {
                    "type": "responseTime",
                    "property": "",
                    "comparison": "lessThan",
                    "target": "500"
                },
                {
                    "type": "statusCode",
                    "property": "",
                    "comparison": "equalTo",
                    "target": "200"
                },
                {
                    "type": "header",
                    "property": "access-control-allow-origin",
                    "comparison": "equalTo",
                    "target": "*"
                },
                {
                    "type": "body",
                    "property": "",
                    "comparison": "contains",
                    "target": "_id"
                }
            ]
        },
        "alertChannels": [
            {
                "id": "94db2374-a765-4f93-9d3b-114fabfa21f0",
                "type": "discord",
                "destination": "https://discord.com/api/webhooks/999824136513798254/-tZUo-kvKnBFJB9b0htqMu2zgaWA2CA_da1h8O3H6AgLYP_E4FpOe6sczmuqc9vpJ703",
                "alertsOnRecovery": false,
                "alertsOnFailure": true
            }
        ]
    }
}
```

And saw the following in the DB and Event Bridge:

<img width="1216" alt="Screen Shot 2022-07-31 at 12 13 29 PM" src="https://user-images.githubusercontent.com/30358327/182041643-f59cc106-c7e7-4bc0-87b0-677365a81e0f.png">

<img width="1047" alt="Screen Shot 2022-07-31 at 12 14 07 PM" src="https://user-images.githubusercontent.com/30358327/182041663-9ba805f8-4cc7-493a-be6d-6d34642dfbab.png">

<img width="555" alt="Screen Shot 2022-07-31 at 12 12 06 PM" src="https://user-images.githubusercontent.com/30358327/182041614-495bfa41-96f1-4b19-94af-66b1ead24a70.png">

## End to end test after merge
Created the following config in the UI:
<img width="646" alt="Screen Shot 2022-07-31 at 12 43 45 PM" src="https://user-images.githubusercontent.com/30358327/182042637-bb610ff7-5950-41a1-8494-549f9b703cdb.png">

Soon after, saw results in the UI: 
<img width="874" alt="Screen Shot 2022-07-31 at 12 46 46 PM" src="https://user-images.githubusercontent.com/30358327/182042654-a4393fbf-228a-417b-9d80-d13c217d7615.png">

Noticed the alert wasn't working despite failed test runs and realized it was due to a mismatch between the alert type and destination. I fixed the mismatch and made a few other changes which I then passed as the payload to `PUT /api/tests/96`:
```json
{
    "test": {
        "title": "0731-t7",
        "locations": [
            "us-east-1"
        ],
        "minutesBetweenRuns": "60",
        "type": "api",
        "httpRequest": {
            "method": "get",
            "url": "https://trellific.corkboard.dev/api/boards",
            "headers": {
                "Content-Type": "application/json"
            },
            "body": {
                "board": {
                    "title": "0731-t7 board (edit 1)"
                }
            },
            "assertions": [
                {
                    "type": "responseTime",
                    "property": "",
                    "comparison": "lessThan",
                    "target": "200"
                },
                {
                    "type": "statusCode",
                    "property": "",
                    "comparison": "equalTo",
                    "target": "200"
                },
                {
                    "type": "header",
                    "property": "access-control-allow-origin",
                    "comparison": "equalTo",
                    "target": "*"
                },
                {
                    "type": "body",
                    "property": "",
                    "comparison": "contains",
                    "target": "_id"
                }
            ]
        },
        "alertChannels": [
            {
                "id": "94db2374-a765-4f93-9d3b-114fabfa21f0",
                "type": "discord",
                "destination": "https://discord.com/api/webhooks/999824136513798254/-tZUo-kvKnBFJB9b0htqMu2zgaWA2CA_da1h8O3H6AgLYP_E4FpOe6sczmuqc9vpJ703",
                "alertsOnRecovery": false,
                "alertsOnFailure": true
            }
        ]
    }
}
```

Which led to several changes including an updated run interval: 
<img width="840" alt="Screen Shot 2022-07-31 at 12 51 26 PM" src="https://user-images.githubusercontent.com/30358327/182042782-dffb25bc-0086-431f-a1ec-003413891a8b.png">

And fixed the alerts: 

<img width="707" alt="Screen Shot 2022-07-31 at 12 52 47 PM" src="https://user-images.githubusercontent.com/30358327/182042830-2658e28b-bc7a-4948-8f35-750aa978c912.png">

