### PR TITLE
add assertionId, test_id and alerts data to json payload

### DIFF
--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -69,7 +69,8 @@ async function getTestBody(testId) {
   `;
 
   const assertionQuery = `
-  SELECT 
+  SELECT
+   a.id, 
    a.type,
    a.property,
    ct.name as comparison,
@@ -87,16 +88,30 @@ async function getTestBody(testId) {
       JOIN test_runs tr ON r.id = tr.region_id
       WHERE tr.test_id = ${testId};
     `;
+  const alertsQuery = `
+    SELECT 
+      a.type,
+      a.destination,
+      ns.alerts_on_recovery,
+      ns.alerts_on_failure
+      FROM 
+      notification_settings ns
+       JOIN alerts a ON ns.id = a.notification_settings_id
+       JOIN tests_alerts ts ON ts.alerts_id = a.id
+       WHERE ts.test_id = ${testId} 
+  `;
 
   const testCofnig = await dbQuery(configQuery);
   const assertions = await dbQuery(assertionQuery);
   const locations = await dbQuery(locationQuery);
+  const alerts = await dbQuery(alertsQuery);
 
   // eslint-disable-next-line object-curly-newline
   const { name, frequency, headers, body, url, method } = testCofnig.rows[0];
 
   const json = {
     test: {
+      id: +testId,
       title: name,
       locations: locations.rows.map((location) => location.aws_name),
       minutesBetweenRuns: frequency,
@@ -108,6 +123,7 @@ async function getTestBody(testId) {
         body: body || {},
         assertions: assertions.rows,
       },
+      alertChannels: alerts.rows,
     },
   };
   return json;


### PR DESCRIPTION
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>

This PR: 
- adds `test_id` and alerts array to the JSON body produced for Run Now functionality.

- Send a test request from a Postman and it made it all the way to the UI. 
- The JSON body for the test looks as follows:
```javascript
{
    "test": {
        "id": 109,
        "title": "katarina07",
        "locations": [
            "us-east-1"
        ],
        "minutesBetweenRuns": 1,
        "type": "api",
        "httpRequest": {
            "method": "get",
            "url": "https://trellific.corkboard.dev/api/boards",
            "headers": {},
            "body": {},
            "assertions": [
                {
                    "id": 298,
                    "type": "statusCode",
                    "property": null,
                    "comparison": "equalTo",
                    "target": "200"
                }
            ]
        },
        "alertChannels": []
    }
}
``` 