### PR TITLE
fix lookup issue caused by null assertion target value

### DIFF
--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -42,12 +42,12 @@ const createEventBridgeRule = async (reqBody) => {
 const assignAssertionIds = (requestAssertions, dbAssertions) => {
   const dbAssertionsLookup = {};
   dbAssertions.forEach((a) => {
-    const assertionKey = `${a.type}-${a.property ? a.property : ''}-${comparisonIdToType(a.comparison_type_id)}-${a.expected_value}}`;
+    const assertionKey = `${a.type}-${a.property ? a.property : ''}-${comparisonIdToType(a.comparison_type_id)}-${a.expected_value ? a.expected_value : ''}}`;
     dbAssertionsLookup[assertionKey] = a;
   });
 
   requestAssertions.forEach((a) => {
-    const assertionKey = `${a.type}-${a.property ? a.property : ''}-${a.comparison}-${a.target}}`;
+    const assertionKey = `${a.type}-${a.property ? a.property : ''}-${a.comparison}-${a.target ? a.target : ''}}`;
     const assertionId = dbAssertionsLookup[assertionKey].id;
     a.id = assertionId;
   });


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

Fix lookup issue caused by null assertion target value. A null value previously caused a mismatch in the lookup key between the database value and the JSON value.

# Validation
Successfully created a test (and tested end-to-end) which included a null assertion target

<img width="1241" alt="Screen Shot 2022-08-10 at 9 37 34 PM" src="https://user-images.githubusercontent.com/30358327/184065594-ea0bcac6-b2ed-4704-a83f-c2afbc9986e3.png">

