### PR TITLE
add test regions on test creation and edit

### DIFF
--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -63,6 +63,7 @@ const createTest = async (req, res) => {
       const assertionsData = await queries.addTestAssertions(testId, test.httpRequest.assertions);
       assignAssertionIds(test.httpRequest.assertions, assertionsData);
       await queries.addTestAlerts(testId, test.alertChannels);
+      await queries.addTestRegions(testId, test.locations);
       await createEventBridgeRule(req.body);
       res.status(201).send(`Test ${req.body.test.title} created`);
     } catch (err) {
@@ -108,6 +109,8 @@ const editTest = async (req, res) => {
       assignAssertionIds(test.httpRequest.assertions, assertionsData);
       await queries.deleteTestAlerts(testId);
       await queries.addTestAlerts(testId, test.alertChannels);
+      await queries.deleteTestRegions(testId);
+      await queries.addTestRegions(testId, test.locations);
       await editEventBridgeRule(req.body);
       res.status(200).send(`Test ${req.body.test.title} updated`);
     } catch (err) {

--- a/lib/db/queries/addTestRegions.js
+++ b/lib/db/queries/addTestRegions.js
@@ -1,0 +1,20 @@
+const { regionNameToId } = require('../../../utils/helpers');
+const { dbQuery } = require('../conn');
+
+async function addTestRegions(testId, regions) {
+  let query = `
+    INSERT INTO tests_regions (test_id, region_id)
+    VALUES
+  `;
+  regions.forEach((region) => {
+    const regionId = regionNameToId(region);
+    query += `(${testId}, '${regionId}'),`;
+  });
+
+  let queryCopy = query.slice(0, query.length - 1).replace(/'null'/g, null);
+  queryCopy += ' RETURNING id, test_id, region_id;';
+  const result = await dbQuery(queryCopy);
+  return result.rows;
+}
+
+module.exports = addTestRegions;

--- a/lib/db/queries/deleteTestRegions.js
+++ b/lib/db/queries/deleteTestRegions.js
@@ -1,0 +1,12 @@
+const { dbQuery } = require('../conn');
+
+async function deleteTestRegions(testId) {
+  const deleteRegionsQuery = `
+    DELETE FROM tests_regions 
+    WHERE test_id = '${testId}'
+  `;
+  const result = await dbQuery(deleteRegionsQuery);
+  return result.rows;
+}
+
+module.exports = deleteTestRegions;

--- a/lib/db/queries/index.js
+++ b/lib/db/queries/index.js
@@ -3,10 +3,12 @@ const getTestRuns = require('./getTestRuns');
 const addNewTest = require('./addNewTest');
 const addTestAssertions = require('./addTestAssertions');
 const addTestAlerts = require('./addTestAlerts');
+const addTestRegions = require('./addTestRegions');
 const editTest = require('./editTest');
 const deactivateTestAssertions = require('./deactivateTestAssertions');
 const deleteTestAlerts = require('./deleteTestAlerts');
 const deleteTest = require('./deleteTest');
+const deleteTestRegions = require('./deleteTestRegions');
 const getSideload = require('./getSideload');
 const getTests = require('./getTests');
 const getTestName = require('./getTestName');
@@ -25,10 +27,12 @@ module.exports = {
   addNewTest,
   addTestAssertions,
   addTestAlerts,
+  addTestRegions,
   editTest,
   deactivateTestAssertions,
   deleteTestAlerts,
   deleteTest,
+  deleteTestRegions,
   getSideload,
   getTests,
   getTestName,

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -54,6 +54,35 @@ const comparisonIdToType = (id) => {
   }[id];
 };
 
+const regionNameToId = (awsRegionName) => {
+  return {
+    'us-east-1': 1,
+    'us-east-2': 2,
+    'us-west-1': 3,
+    'us-west-2': 4,
+    'ca-central-1': 5,
+    'sa-east-1': 6,
+    'eu-north-1': 7,
+    'eu-west-3': 8,
+    'eu-west-2': 9,
+    'eu-west-1': 10,
+    'eu-central-1': 11,
+    'eu-south-1': 12,
+    'me-south-1': 13,
+    'af-south-1': 14,
+    'ap-southeast-1': 15,
+    'ap-northeast-1': 16,
+    'ap-northeast-3': 17,
+    'ap-east-1': 18,
+    'ap-southeast-2': 19,
+    'ap-southeast-3': 20,
+    'ap-northeast-2': 21,
+    'ap-south-1': 22,
+
+  }[awsRegionName];
+};
+
 module.exports.httpMethodToId = httpMethodToId;
 module.exports.comparisonTypeToId = comparisonTypeToId;
 module.exports.comparisonIdToType = comparisonIdToType;
+module.exports.regionNameToId = regionNameToId;


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR adds to the `tests_regions` table during test config creation and edits.

# Validation
Ran `tests-crud` locally and made the following request to `POST http://localhost:5001/api/tests` with the following payload:
```
{
    "test": {
        "title": "0813-t1",
        "locations": [
            "us-east-1",
            "us-west-1"
        ],
        "minutesBetweenRuns": "1",
        "type": "api",
        "httpRequest": {
            "method": "post",
            "url": "https://trellific.corkboard.dev/api/boards",
            "headers": {
                "Content-Type": "application/json"
            },
            "body": {
                "board": {
                    "title": "0813-t1 board"
                }
            },
            "assertions": [
                {
                    "type": "responseTime",
                    "property": "",
                    "comparison": "lessThan",
                    "target": "500"
                },
                {
                    "type": "statusCode",
                    "property": "",
                    "comparison": "equalTo",
                    "target": "200"
                },
                {
                    "type": "body",
                    "property": "",
                    "comparison": "contains",
                    "target": "_id"
                }
            ]
        }
    }
}
```

This resulted in a successful test creation:

<img width="1289" alt="Screen Shot 2022-08-13 at 3 25 31 PM" src="https://user-images.githubusercontent.com/30358327/184515313-c2967510-a916-4be9-82c5-2b2d5d5a7285.png">

...and the following rows in `tests_regions`:

<img width="916" alt="Screen Shot 2022-08-13 at 3 25 09 PM" src="https://user-images.githubusercontent.com/30358327/184515296-4567fbf7-b357-4e70-a0e0-596a04ee507f.png">

Subsequently, made the following request: `PUT http://localhost:5001/api/tests/176` with the following payload: 
```
{
    "test": {
        "title": "0813-t1",
        "locations": [
            "eu-north-1",
            "us-west-1"
        ],
        "minutesBetweenRuns": "1",
        "type": "api",
        "httpRequest": {
            "method": "post",
            "url": "https://trellific.corkboard.dev/api/boards",
            "headers": {
                "Content-Type": "application/json"
            },
            "body": {
                "board": {
                    "title": "0813-t1 board"
                }
            },
            "assertions": [
                {
                    "type": "responseTime",
                    "property": "",
                    "comparison": "lessThan",
                    "target": "500"
                },
                {
                    "type": "statusCode",
                    "property": "",
                    "comparison": "equalTo",
                    "target": "200"
                },
                {
                    "type": "body",
                    "property": "",
                    "comparison": "contains",
                    "target": "_id"
                }
            ]
        }
    }
}
```

This resulted in a successful test update:

<img width="673" alt="Screen Shot 2022-08-13 at 3 32 19 PM" src="https://user-images.githubusercontent.com/30358327/184515460-2edc06a1-a4ec-466f-8d7a-cf60514f4d5b.png">

...and the following rows in `tests_regions`:

<img width="890" alt="Screen Shot 2022-08-13 at 3 32 47 PM" src="https://user-images.githubusercontent.com/30358327/184515465-82685636-c478-48f3-a99e-868fc8b21321.png">

