### PR TITLE
remove inactive assertions from get test endpoint

### DIFF
--- a/lib/db/queries/getTestBody.js
+++ b/lib/db/queries/getTestBody.js
@@ -24,7 +24,8 @@ async function getTestBody(testId) {
   FROM assertions a
     JOIN comparison_types ct
     ON a.comparison_type_id = ct.id
-    WHERE a.test_id = ${testId};
+    WHERE a.test_id = ${testId}
+    AND a.active = true;
    `;
 
   const locationQuery = `


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

Currently, all assertions (including those that are no longer active) are shown in the edit view:

<img width="1332" alt="Screen Shot 2022-08-15 at 11 12 15 AM" src="https://user-images.githubusercontent.com/30358327/184691700-22ccb703-7459-4478-83a6-4c80fb9876b6.png">

This PR removes those assertions from the `GET /api/tests/:id` endpoint.
 